### PR TITLE
Improve authorization robustness and performance

### DIFF
--- a/packages/test-app-frontend/src/App/App.tsx
+++ b/packages/test-app-frontend/src/App/App.tsx
@@ -12,7 +12,7 @@ import { applyUrlPrefix, clientId } from "../environment";
 import "./App.css";
 import { AppHeader } from "./AppHeader";
 import {
-  AuthorizationState, createAuthorizationProvider, SignInCallback, SignInSilent, useAuthorization
+  AuthorizationState, createAuthorizationProvider, SignInCallback, SignInSilent, SignInSilentCallback, useAuthorization
 } from "./Authorization";
 import { LoadingScreen } from "./common/LoadingScreen";
 import { ErrorPage } from "./errors/ErrorPage";
@@ -30,8 +30,8 @@ export function App(): ReactElement {
         </PageLayout.Header>
         <Routes>
           <Route path="/auth/callback" element={<SignInCallback />} />
-          <Route path="/auth/silent" element={<SignInSilent />} />
-          <Route path="/*" element={<Main />} />
+          <Route path="/auth/silent" element={<SignInSilentCallback />} />
+          <Route path="/*" element={<><SignInSilent /><Main /></>} />
         </Routes>
       </PageLayout>
     </AuthorizationProvider>
@@ -107,8 +107,13 @@ function SignInPrompt(props: SignInPromptProps): ReactElement {
 
 function useBackgroundITwinJsAppLoading(): typeof ITwinJsApp | undefined {
   const [itwinJsApp, setITwinJsApp] = useState<typeof ITwinJsApp>();
+  const { userAuthorizationClient } = useAuthorization();
   useEffect(
     () => {
+      if (!userAuthorizationClient) {
+        return;
+      }
+
       let disposed = false;
       void (async () => {
         const { ITwinJsApp, initializeITwinJsApp } = await import("./ITwinJsApp/ITwinJsApp");
@@ -120,7 +125,7 @@ function useBackgroundITwinJsAppLoading(): typeof ITwinJsApp | undefined {
 
       return () => { disposed = true; };
     },
-    [],
+    [userAuthorizationClient],
   );
   return itwinJsApp;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,7 +222,7 @@ importers:
       '@types/react': 17.0.52
       '@types/react-dom': 17.0.18
       '@vitejs/plugin-react-swc': 3.0.1_vite@4.0.4
-      oidc-client-ts: 2.1.0
+      oidc-client-ts: 2.2.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-redux: 7.2.2_ykxqnxanlq42xavzz22bjdrwni
@@ -4637,8 +4637,8 @@ packages:
       es-abstract: 1.20.4
     dev: false
 
-  /oidc-client-ts/2.1.0:
-    resolution: {integrity: sha512-Rmfl/10g7tTLy8cXezn0Ek+Wa3bKwNnW7oRzLB/hU5EK/DC1D/W1d0GCjGf23WYd6b4Ifa8ud/NzgsMOnbNp8Q==}
+  /oidc-client-ts/2.2.1:
+    resolution: {integrity: sha512-g/W+DsUVeHZ8A7xUSTeK4bI6BNs9ROtMiiOOo+0M6IiTHxueJ757GD8e/8nPBL+k/o6bkfM5mWg4cZcSI8Iosw==}
     engines: {node: '>=12.13.0'}
     dependencies:
       crypto-js: 4.1.1


### PR DESCRIPTION
I found two problems with existing authorization implementation:

* Vite queues a huge amount of requests for `.ts` files, which forces authorization to stall until these requests are cleared. Sometimes the wait is long enough to cause oidc-client-ts to timeout and fail silent sign-in check.
* Normally we perform a silent sign-in on app startup to authorize the user in the background. When it fails, we direct the user to sign-in normally and handle the result on authorization callback URL. The problem is, after signing-in the user this way, we still are performing the silent sign-in when the app starts initializing again.

This PR makes the following changes:

* Delay iTwinJsApp loading until the user is signed in. This will reduce possibility for authorization request to timeout.
* Do not perform a silent sign-in if user has already signed-in in other way.