### PR TITLE
Improve property comparison table header layout

### DIFF
--- a/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.scss
+++ b/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.scss
@@ -11,48 +11,16 @@
 
   .property-comparison-table {
     > .header {
-      display: flex;
-      padding: $uicore-s;
-      align-items: center;
+      padding: $uicore-s $uicore-m;
       background-color: $buic-background-widget;
-
-      > .slider-container {
-        display: flex;
-        justify-content: center;
-        margin: auto;
-        padding-left: $uicore-s;
-        width: 50%;
-
-        > .slider-overrides {
-          padding-left: $uicore-s;
-          padding-right: $uicore-s;
-          margin-top: auto;
-          margin-bottom: auto;
-          width: 50%;
-        }
-
-        > .slider-label {
-          @include uicore-font-family;
-          font-size: $uicore-font-size-leading;
-          color: $buic-text-color;
-          padding: $uicore-s;
-          margin: auto;
-        }
-      }
-
-      > .element-picker {
-        padding: $uicore-s;
-        padding-right: $uicore-l;
-        width: 15%;
-
-        > .select-picker {
-          width: 100%;
-          vertical-align: top;
-        }
-      }
+      display: grid;
+      grid: 1fr / auto 1fr auto auto;
+      grid-template-areas: "element-label slider settings navigation";
+      gap: 16px;
+      place-items: center;
 
       > .header-element-label {
-        padding-left: $uicore-s;
+        grid-area: element-label;
 
         > .header-element-label-text {
           @include uicore-font-family;
@@ -74,13 +42,30 @@
         }
       }
 
-      > .go-left {
-        margin-left: auto;
+      > .iui-slider-component-container {
+        width: 100%;
+        justify-content: center;
+
+        .iui-slider-container {
+          min-width: 200px;
+          max-width: 800px;
+        }
       }
 
-      > .chevron-button {
-        cursor: pointer;
-        padding: $uicore-s;
+      > .settings {
+        grid-area: settings;
+        display: flex;
+        gap: 16px;
+      }
+
+      > .property-navigation {
+        grid-area: navigation;
+        display: flex;
+
+        > .chevron-button {
+          cursor: pointer;
+          padding: $uicore-s;
+        }
       }
     }
   }

--- a/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.tsx
+++ b/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.tsx
@@ -13,7 +13,8 @@ import {
 } from "@itwin/components-react";
 import { Logger } from "@itwin/core-bentley";
 import { IModelApp, IModelConnection } from "@itwin/core-frontend";
-import { LoadingSpinner, Slider, Toggle } from "@itwin/core-react";
+import { LoadingSpinner } from "@itwin/core-react";
+import { Slider, ToggleSwitch } from "@itwin/itwinui-react";
 import { KeySet } from "@itwin/presentation-common";
 import { PresentationPropertyDataProvider } from "@itwin/presentation-components";
 import { Presentation, type SelectionChangeEventArgs } from "@itwin/presentation-frontend";
@@ -74,22 +75,15 @@ export class OverviewOpacitySlider extends Component<OverviewOpacitySliderProps>
 
   public override render() {
     return (
-      <div className="slider-container">
-        <div className="slider-label">
-          {this.props.manager.currentVersion?.displayName}
-        </div>
-        <Slider
-          className="slider-overrides"
-          min={0}
-          max={100}
-          values={[50]}
-          showTooltip={false}
-          onUpdate={this._onOpacitySliderChange}
-        />
-        <div className="slider-label">
-          {this.props.manager.targetVersion?.displayName}
-        </div>
-      </div>
+      <Slider
+        min={0}
+        max={100}
+        values={[50]}
+        onUpdate={this._onOpacitySliderChange}
+        minLabel={this.props.manager.currentVersion?.displayName}
+        maxLabel={this.props.manager.targetVersion?.displayName}
+        tooltipProps={() => ({ visible: false })}
+      />
     );
   }
 }
@@ -875,32 +869,35 @@ export class PropertyComparisonTable extends Component<PropertyComparisonProps, 
           this.state.manager.wantNinezone && !this.state.sideBySide &&
           <OverviewOpacitySlider manager={this.state.manager} />
         }
-        <div className="go-left" />
-        {
-          this.state.manager.wantNinezone &&
-          <>
-            <Toggle isOn={this.state.sideBySide} onChange={this._onToggleInspectMode} />
-            <div className="header-toggle-label">
-              {IModelApp.localization.getLocalizedString("VersionCompare:versionCompare.sideBySide")}
-            </div>
-          </>
-        }
-        <Toggle isOn={this.state.showChangedOnly} onChange={setShowChanged} />
-        <div className="header-toggle-label">
-          {IModelApp.localization.getLocalizedString("VersionCompare:versionCompare.onlyChangedProps")}
+        <div className="settings">
+          {
+            this.state.manager.wantNinezone &&
+            <ToggleSwitch
+              checked={this.state.sideBySide}
+              onChange={this._onToggleInspectMode}
+              label={IModelApp.localization.getLocalizedString("VersionCompare:versionCompare.sideBySide")}
+            />
+          }
+          <ToggleSwitch
+            checked={this.state.showChangedOnly}
+            onChange={setShowChanged}
+            label={IModelApp.localization.getLocalizedString("VersionCompare:versionCompare.onlyChangedProps")}
+          />
         </div>
-        <div
-          className="chevron-button icon icon-chevron-up"
-          title={IModelApp.localization.getLocalizedString("VersionCompare:versionCompare.scrollToChangedProperty")}
-          onClick={() => this.handleCycle(true)}
-          data-testid="pct-up-chevron"
-        />
-        <div
-          className="chevron-button icon icon-chevron-down"
-          title={IModelApp.localization.getLocalizedString("VersionCompare:versionCompare.scrollToChangedProperty")}
-          onClick={() => this.handleCycle(false)}
-          data-testid="pct-down-chevron"
-        />
+        <div className="property-navigation">
+          <div
+            className="chevron-button icon icon-chevron-up"
+            title={IModelApp.localization.getLocalizedString("VersionCompare:versionCompare.scrollToChangedProperty")}
+            onClick={() => this.handleCycle(true)}
+            data-testid="pct-up-chevron"
+          />
+          <div
+            className="chevron-button icon icon-chevron-down"
+            title={IModelApp.localization.getLocalizedString("VersionCompare:versionCompare.scrollToChangedProperty")}
+            onClick={() => this.handleCycle(false)}
+            data-testid="pct-down-chevron"
+          />
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
* Reformat `PropertyComparisonTable.tsx`
* Replace deprecated appui components with alternatives from itwinui-react package
* Redo table header layout

Before:
![chrome_nqtnMLU7Ji](https://user-images.githubusercontent.com/70327485/222174571-6a082ff7-1af7-4707-90bf-1d8f24896738.png)

After:
![chrome_JyVHvawN7K](https://user-images.githubusercontent.com/70327485/222174598-77ffb619-a3d5-4a91-95b1-9e067f9d664b.png)

Both screenshots were taken at 1200px horizontal resolution.
