### PR TITLE
Fix comparison icon being always visible

### DIFF
--- a/packages/changed-elements-react/src/widgets/ElementNodeComponent.tsx
+++ b/packages/changed-elements-react/src/widgets/ElementNodeComponent.tsx
@@ -174,7 +174,7 @@ export class ElementNodeComponent extends React.Component<ElementListNodeProps> 
         <IconButton
           size="small"
           styleType="borderless"
-          className={`vc-element-inspect-button" ${(
+          className={`vc-element-inspect-button ${(
             this.props.selected &&
             !this.props.isModel &&
             this.props.opcode !== undefined &&


### PR DESCRIPTION
Fixes a mistake that was made while removing uses of `classnames` package.