### PR TITLE
Make vite pre-bundle changed-elements-react dependencies

### DIFF
--- a/packages/test-app-frontend/vite.config.ts
+++ b/packages/test-app-frontend/vite.config.ts
@@ -60,6 +60,7 @@ export default defineConfig(() => ({
       },
     ],
   },
+  optimizeDeps: { entries: ["./src/**", "../changed-elements-react/src/**"] },
   server: {
     port: 2363,
   },


### PR DESCRIPTION
Vite annoyingly reloads the entire app while the developer is using it when iTwinJsApp portion of it finally loads for the first time.

Vite does not automatically discover all dependencies of our test app. When it finds out that we load additional code, it recalculates its internal dependency graph and produces new bundles.

With this change we tell vite to scan through changed-elements-react source tree and collect the dependency graph ahead of time.