### PR TITLE
Re-export all changed-elements-react package contents in root index.ts

### DIFF
--- a/packages/changed-elements-react/index.ts
+++ b/packages/changed-elements-react/index.ts
@@ -2,5 +2,4 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-export { VersionCompare, VersionCompareSelectDialog, type VersionCompareSelectDialogProps } from "./src/index";
-export { ChangedElementsWidget } from "./src/index";
+export * from "./src/index";


### PR DESCRIPTION
This index file is only required for Visual Studio Code intellisense to work correctly. It is not shipped with the final @itwin/changed-elements-react package.