### PR TITLE
Remove publishing workaround for types field

### DIFF
--- a/packages/changed-elements-react/package.json
+++ b/packages/changed-elements-react/package.json
@@ -13,9 +13,14 @@
   "main": "./lib/cjs/index.js",
   "exports": {
     ".": {
-      "import": "./lib/esm/index.js",
-      "require": "./lib/cjs/index.js",
-      "types": "./src/index.ts"
+      "import": {
+        "types": "./lib/esm/index.d.ts",
+        "default": "./lib/esm/index.js"
+      },
+      "require":  {
+        "types": "./lib/cjs/index.d.ts",
+        "default": "./lib/cjs/index.js"
+      }
     }
   },
   "files": [

--- a/packages/test-app-frontend/tsconfig.json
+++ b/packages/test-app-frontend/tsconfig.json
@@ -8,6 +8,9 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "esModuleInterop": true,
+    "paths": {
+      "@itwin/changed-elements-react": [ "../changed-elements-react/src/index.ts" ],
+    },
   },
   "include": [ "src" ],
   "references": [ { "path": "./tsconfig.node.json" } ]

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -41,8 +41,6 @@ function main(): void {
 
   console.log(`Successfully bumped ${packageName} version and committed the changes.
 Release tag: v${packageVersion}`);
-
-  processPackageJson(args.packageJsonFilePath);
 }
 
 function readPackageJson(packageJsonFilePath: string): { packageName: string; packageVersion: string; } {
@@ -58,19 +56,6 @@ function readPackageJson(packageJsonFilePath: string): { packageName: string; pa
   }
 
   return { packageName, packageVersion };
-}
-
-function processPackageJson(packageJsonFilePath: string): void {
-  const packageJson = JSON.parse(fs.readFileSync(packageJsonFilePath, { encoding: "utf-8" }));
-
-  // Remove fields that are not needed in published package
-  delete packageJson.devDependencies;
-  delete packageJson.scripts;
-
-  // Point types field to actual published types
-  packageJson.exports["."].types = packageJson.exports["."].import.replace(".js", ".d.ts");
-
-  fs.writeFileSync(packageJsonFilePath, JSON.stringify(packageJson, undefined, 2));
 }
 
 function updateChangelog(changelogFilePath: string, packageVersion: string): void {


### PR DESCRIPTION
Introduce `paths` setting in `test-app-frontend/tsconfig.json` to override `@itwin/changed-elements-react` types location in dev environment. This removes the need for pre-processing `package.json` before packing package files for publishing.

Updated the way type locations are defined in the exports section of the package so that CommonJS module gets its own type definitions.

CRA-based iTwin app template continues to work and use ESM verson of the package.