### PR TITLE
Fixup release process

### DIFF
--- a/packages/changed-elements-react/package.json
+++ b/packages/changed-elements-react/package.json
@@ -12,7 +12,6 @@
     "name": "Bentley Systems, Inc.",
     "url": "https://www.bentley.com"
   },
-  "main": "./lib/cjs/index.js",
   "exports": {
     ".": {
       "import": {
@@ -34,7 +33,7 @@
     "build:copy-assets:esm": "cpx \"./src/**/*.{scss,css}\" ./lib/esm",
     "build:copy-assets:cjs": "cpx \"./src/**/*.{scss,css}\" ./lib/cjs",
     "build:transpile:esm": "tsc --project ./tsconfig.build.json",
-    "build:transpile:cjs": "tsc --project ./tsconfig.build.json --module CommonJS --outDir ./lib/cjs",
+    "build:transpile:cjs": "tsc --project ./tsconfig.build.json --module CommonJS --moduleResolution Node16 --outDir ./lib/cjs",
     "test": "vitest run",
     "test:cover": "vitest run --coverage",
     "test:watch": "vitest watch",

--- a/packages/changed-elements-react/publish.yaml
+++ b/packages/changed-elements-react/publish.yaml
@@ -30,9 +30,9 @@ stages:
             fetchDepth: 1
 
           - task: NodeTool@0
-            displayName: Use Node.js 16.x
+            displayName: Use Node.js 18.x
             inputs:
-              versionSpec: 16.x
+              versionSpec: 18.x
 
           - task: CmdLine@2
             displayName: Install pnpm


### PR DESCRIPTION
* Use Node.js 18.x in the release pipeline
* `main` field in `package.json` was causing an extra `././lib/cjs/index.js` file to be included in the package (not a typo)
* Fix `"moduleResolution": "bundler"` setting being used during transpilation when it's not allowed for `CommonJS` modules