### PR TITLE
Fix ElementsList scroll offset not being restored

### DIFF
--- a/packages/changed-elements-react/CHANGELOG.md
+++ b/packages/changed-elements-react/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased](https://github.com/iTwin/changed-elements-react/tree/HEAD/packages/changed-elements-react)
 
+### Fixes
+
+* Fix Elements Widget failing to restore its previous scroll offset when used as AppUI widget
+
 ## [0.1.0](https://github.com/iTwin/changed-elements-react/tree/v0.1.0/packages/changed-elements-react) - 2023-06-15
 
 Initial package release.

--- a/packages/changed-elements-react/src/widgets/ElementsList.tsx
+++ b/packages/changed-elements-react/src/widgets/ElementsList.tsx
@@ -2,11 +2,12 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
+import { useTransientState } from "@itwin/appui-react";
 import type { TreeNodeItem } from "@itwin/components-react";
 import { BeEvent } from "@itwin/core-bentley";
 import { Presentation, type SelectionChangeEventArgs } from "@itwin/presentation-frontend";
-import * as React from "react";
-import { FixedSizeList, type ListChildComponentProps } from "react-window";
+import { useCallback, useEffect, useRef, type ReactElement } from "react";
+import { FixedSizeList } from "react-window";
 import InfiniteLoader from "react-window-infinite-loader";
 
 import { AutoSizer } from "../AutoSizer.js";
@@ -15,172 +16,213 @@ import { ElementNodeComponent } from "./ElementNodeComponent.js";
 import "./ChangedElementsInspector.scss";
 
 export interface ElementsListProps {
-  /** Nodes to display and load */
+  /** Nodes to display and load. */
   nodes: TreeNodeItem[];
-  /** Called when infinite spinner wants to load the given nodes */
+
+  /** Called when infinite spinner wants to load the given nodes. */
   loadNodes: (nodes: TreeNodeItem[]) => Promise<void>;
-  /** Should return true if the node is loaded */
+
+  /** Should return true if the node is loaded. */
   isLoaded: (node: TreeNodeItem) => boolean;
-  /** Message to show when array of nodes is empty */
+
+  /** Message to show when array of nodes is empty. */
   emptyMessage: string;
-  /** Whether a node is visible in the view or not */
+
+  /** Whether a node is visible in the view or not. */
   isVisible: (node: TreeNodeItem) => boolean;
-  /** Toggle visibility of node/element */
+
+  /** Toggle visibility of node/element. */
   toggleVisibility: (node: TreeNodeItem) => void;
-  /** On clicking the inspect chevron of the node */
+
+  /** On clicking the inspect chevron of the node. */
   onInspect: (node: TreeNodeItem) => Promise<void>;
-  /** On selecting the node in the list */
+
+  /** On selecting the node in the list. */
   onNodeClick: (node: TreeNodeItem) => void;
-  /** On property compare icon click */
+
+  /** On property compare icon click. */
   onPropertyCompare: () => void;
-  /** Whether the node is currently selected */
+
+  /** Whether the node is currently selected. */
   isSelected: (node: TreeNodeItem) => boolean;
-  /** Whether a node has children and should show a chevron */
+
+  /** Whether a node has children and should show a chevron. */
   hasChildren: (node: TreeNodeItem) => boolean;
-  /** Event triggered when nodes should be reloaded in the list */
+
+  /** Event triggered when nodes should be reloaded in the list. */
   nodesReloaded: BeEvent<() => void>;
 }
 
-/**
- * InfiniteLoader list of elements that will load on demand as user scrolls
- */
-export class ElementsList extends React.Component<ElementsListProps> {
-  private _listRef = React.createRef<FixedSizeList>();
-  private _loaderRef = React.createRef<InfiniteLoader>();
+export function ElementsList(props: ElementsListProps): ReactElement {
+  const elementListRef = useRef<HTMLDivElement>(null);
+  const loaderRef = useRef<InfiniteLoader>(null);
+  const listRef = useRef<FixedSizeList>(null);
 
-  private _resetCache = () => {
-    if (this._loaderRef.current !== null) {
-      this._loaderRef.current.resetloadMoreItemsCache(true);
-    }
-  };
+  useEffect(
+    () => {
+      const handleSelectionChanged = (args: SelectionChangeEventArgs) => {
+        let ids: string[] = [];
 
-  public override componentDidMount() {
-    Presentation.selection.selectionChange.addListener(this._selectionChangedHandler);
-    this.props.nodesReloaded.addListener(this._resetCache);
-  }
+        args.keys.instanceKeys.forEach((keys) => {
+          ids = [...ids, ...keys];
+        });
 
-  public override componentWillUnmount() {
-    Presentation.selection.selectionChange.removeListener(this._selectionChangedHandler);
-    this.props.nodesReloaded.removeListener(this._resetCache);
-  }
+        // Add selection set of elements that presentation added
+        const allIds = new Set([...ids, ...args.imodel.selectionSet.elements]);
 
-  private _loadMoreItems = async (
-    startIndex: number,
-    stopIndex: number,
-  ): Promise<void> => {
-    const slice = this.props.nodes.slice(startIndex, stopIndex + 1);
-    await this.props.loadNodes(slice);
-  };
+        const findNodeToFocus = () => {
+          for (const node of props.nodes) {
+            if (allIds.has(node.id)) {
+              return node;
+            } else if (node.extendedData?.children !== undefined) {
+              const children: string[] = node.extendedData.children;
+              if (children.some(allIds.has)) {
+                return node;
+              }
+            }
+          }
 
-  private _isItemLoaded = (index: number) => {
-    const entry = this.props.nodes[index];
-    return this.props.isLoaded(entry);
-  };
+          return undefined;
+        };
 
-  /** Try scrolling to the selected element entry if shown */
-  private _selectionChangedHandler = (args: SelectionChangeEventArgs) => {
-    let ids: string[] = [];
-
-    args.keys.instanceKeys.forEach((keys: Set<string>) => {
-      ids = [...ids, ...keys];
-    });
-
-    // Add selection set of elements that presentation added
-    const allIds = new Set([...ids, ...args.imodel.selectionSet.elements]);
-
-    const findNodeToFocus = () => {
-      for (const node of this.props.nodes) {
-        if (allIds.has(node.id)) {
-          return node;
-        } else if (node.extendedData?.children !== undefined) {
-          const children: string[] = node.extendedData.children as string[];
-          if (children.some(allIds.has)) {
-            return node;
+        if (ids.length !== 0 && listRef.current !== null) {
+          const node = findNodeToFocus();
+          if (node !== undefined && args.source !== "ChangedElementsWidget") {
+            const nodeToScroll = props.nodes.findIndex((item) => node.id === item.id);
+            if (nodeToScroll !== -1) {
+              listRef.current.scrollToItem(nodeToScroll, "smart");
+            }
           }
         }
+      };
+
+      Presentation.selection.selectionChange.addListener(handleSelectionChanged);
+      return () => {
+        Presentation.selection.selectionChange.removeListener(handleSelectionChanged);
+      };
+    },
+    [props.nodes],
+  );
+
+  useEffect(
+    () => props.nodesReloaded.addListener(() => {
+      loaderRef.current?.resetloadMoreItemsCache(true);
+    }),
+    [props.nodesReloaded],
+  );
+
+  // Workaround for AppUI bug where widget momentarily appears to have zero height
+  const scrollTopRef = useRef(0);
+  useTransientState(
+    () => {
+      const element = elementListRef.current?.firstChild as HTMLDivElement;
+      if (element) {
+        scrollTopRef.current = element.scrollTop;
       }
-      return undefined;
-    };
-
-    if (ids.length !== 0 && this._listRef.current !== null) {
-      const node = findNodeToFocus();
-      if (node !== undefined && args.source !== "ChangedElementsWidget") {
-        const nodeToScroll = this.props.nodes.findIndex((item: TreeNodeItem) => node.id === item.id);
-        if (nodeToScroll !== -1) {
-          this._listRef.current.scrollToItem(nodeToScroll, "smart");
-        }
+    },
+    () => {
+      const element = elementListRef.current?.firstChild as HTMLDivElement;
+      if (element) {
+        element.scrollTop = scrollTopRef.current;
       }
-    }
-  };
+    },
+  );
 
-  private _renderNode = (item: TreeNodeItem) => {
-    return (
-      <ElementNodeComponent
-        id={item.id}
-        element={item.extendedData?.element}
-        selected={this.props.isSelected(item)}
-        label={item.label}
-        isModel={item.extendedData?.isModel ?? false}
-        opcode={item.extendedData?.element?.opcode}
-        type={item.extendedData?.element?.type ?? 0}
-        wantTypeTooltip={true}
-        hasChildren={this.props.hasChildren(item)}
-        loadingChildren={item.extendedData?.loadingChildren ?? false}
-        visible={this.props.isVisible(item)}
-        toggleVisibility={() => this.props.toggleVisibility(item)}
-        wantChangeSquare={true}
-        onInspect={() => this.props.onInspect(item)}
-        onPropertyCompare={() => this.props.onPropertyCompare()}
-        onClick={() => this.props.onNodeClick(item)}
-        indirect={item.extendedData?.element?.indirect}
-      />
-    );
-  };
+  const isItemLoaded = useCallback(
+    (index: number) => {
+      const entry = props.nodes[index];
+      return (0, props.isLoaded)(entry);
+    },
+    [props.nodes, props.isLoaded],
+  );
 
-  public override render(): React.ReactElement {
-    if (this.props.nodes.length === 0) {
+  const loadMoreItems = useCallback(
+    async (startIndex: number, stopIndex: number) => {
+      const slice = props.nodes.slice(startIndex, stopIndex + 1);
+      await (0, props.loadNodes)(slice);
+    },
+    [props.nodes, props.loadNodes],
+  );
+
+
+  const renderNode = useCallback(
+    (item: TreeNodeItem) => {
       return (
-        <div className="element-list-no-results">
-          {this.props.emptyMessage}
-        </div>
+        <ElementNodeComponent
+          id={item.id}
+          element={item.extendedData?.element}
+          selected={(0, props.isSelected)(item)}
+          label={item.label}
+          isModel={item.extendedData?.isModel ?? false}
+          opcode={item.extendedData?.element?.opcode}
+          type={item.extendedData?.element?.type ?? 0}
+          wantTypeTooltip={true}
+          hasChildren={(0, props.hasChildren)(item)}
+          loadingChildren={item.extendedData?.loadingChildren ?? false}
+          visible={(0, props.isVisible)(item)}
+          toggleVisibility={() => (0, props.toggleVisibility)(item)}
+          wantChangeSquare={true}
+          onInspect={() => (0, props.onInspect)(item)}
+          onPropertyCompare={() => (0, props.onPropertyCompare)()}
+          onClick={() => (0, props.onNodeClick)(item)}
+          indirect={item.extendedData?.element?.indirect}
+        />
       );
-    }
+    },
+    [
+      props.isSelected,
+      props.hasChildren,
+      props.isVisible,
+      props.toggleVisibility,
+      props.onInspect,
+      props.onPropertyCompare,
+      props.onNodeClick,
+    ],
+  );
 
+  if (props.nodes.length === 0) {
     return (
-      <AutoSizer className="element-list">
-        {(size) => {
-          return (
-            <InfiniteLoader
-              ref={this._loaderRef}
-              isItemLoaded={this._isItemLoaded}
-              itemCount={this.props.nodes.length}
-              loadMoreItems={this._loadMoreItems}
-            >
-              {({ onItemsRendered }) => {
-                return (
-                  <FixedSizeList
-                    ref={this._listRef}
-                    style={{ overflow: "overlay" }}
-                    height={size.height}
-                    itemCount={this.props.nodes.length}
-                    onItemsRendered={onItemsRendered}
-                    itemSize={34}
-                    width={size.width}
-                  >
-                    {(props: ListChildComponentProps) => {
-                      return (
-                        <div style={props.style}>
-                          {this._renderNode(this.props.nodes[props.index])}
-                        </div>
-                      );
-                    }}
-                  </FixedSizeList>
-                );
-              }}
-            </InfiniteLoader>
-          );
-        }}
-      </AutoSizer>
+      <div className="element-list-no-results">
+        {props.emptyMessage}
+      </div>
     );
   }
+
+  return (
+    <AutoSizer ref={elementListRef} className="element-list">
+      {(size) => {
+        return (
+          <InfiniteLoader
+            ref={loaderRef}
+            isItemLoaded={isItemLoaded}
+            itemCount={props.nodes.length}
+            loadMoreItems={loadMoreItems}
+          >
+            {({ onItemsRendered }) => {
+              return (
+                <FixedSizeList
+                  ref={listRef}
+                  style={{ overflow: "overlay" }}
+                  height={size.height}
+                  itemCount={props.nodes.length}
+                  onItemsRendered={onItemsRendered}
+                  itemSize={34}
+                  overscanCount={10}
+                  width={size.width}
+                >
+                  {(nodeProps) => {
+                    return (
+                      <div style={nodeProps.style}>
+                        {renderNode(props.nodes[nodeProps.index])}
+                      </div>
+                    );
+                  }}
+                </FixedSizeList>
+              );
+            }}
+          </InfiniteLoader>
+        );
+      }}
+    </AutoSizer>
+  );
 }


### PR DESCRIPTION
AppUI has this bug where when you switch between widget tabs, widgets momentarily have zero height and thus browser becomes unable to restore scroll offset for widget content. This change implements a workaround for this issue by storing and restoring scroll offset manually.

* Refactor `ElementsList` into functional component
* Fix elements list scroll offset not being restored