### PR TITLE
Expose ElementsList ref through ChangedElementsWidget props

### DIFF
--- a/packages/changed-elements-react/CHANGELOG.md
+++ b/packages/changed-elements-react/CHANGELOG.md
@@ -14,10 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 * Update `ChangedElementsWidget` layout
 * Update search bar style in `ChangedElementsWidget`
-
-### Fixes
-
-* Fix Elements Widget failing to restore its previous scroll offset when used as AppUI widget
+* Expose `ElementList` ref through `ChangedElementsWidget` props
 
 ## [0.1.0](https://github.com/iTwin/changed-elements-react/tree/v0.1.0/packages/changed-elements-react) - 2023-06-15
 

--- a/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
+++ b/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
@@ -165,6 +165,7 @@ export class ChangedElementsWidget extends Component<ChangedElementsWidgetProps,
 
     return (
       <ChangedElementsInspector
+        listRef={this.props.rootElementRef}
         manager={this.state.manager}
         onFilterChange={this._onFilterChange}
         onShowAll={this._showAll}

--- a/packages/changed-elements-react/src/widgets/EnhancedElementsInspector.tsx
+++ b/packages/changed-elements-react/src/widgets/EnhancedElementsInspector.tsx
@@ -13,7 +13,7 @@ import {
   ProgressRadial, ToggleSwitch
 } from "@itwin/itwinui-react";
 import { Presentation, type SelectionChangeEventArgs } from "@itwin/presentation-frontend";
-import { Component, createRef, useState, type ReactElement, type SetStateAction } from "react";
+import { Component, createRef, useState, type ReactElement, type Ref, type SetStateAction } from "react";
 
 import { type FilterOptions } from "../SavedFiltersManager.js";
 import type { ChangedElementEntry } from "../api/ChangedElementEntryCache.js";
@@ -36,6 +36,7 @@ export interface ChangedElementsInspectorProps {
   onShowAll: () => Promise<void>;
   onHideAll: () => Promise<void>;
   onInvert: () => Promise<void>;
+  listRef?: Ref<HTMLDivElement>;
 }
 
 /** Get the ChangedElementEntry in a TreeNodeItem. */
@@ -54,6 +55,7 @@ export class ChangedElementsInspector extends Component<ChangedElementsInspector
 
     return (
       <ChangedElementsListComponent
+        listRef={this.props.listRef}
         dataProvider={this.props.manager.changedElementsManager.entryCache.dataProvider}
         manager={this.props.manager}
         onFilterChange={this.props.onFilterChange}
@@ -443,6 +445,7 @@ export interface ChangedElementsListProps {
   onShowAll: () => Promise<void>;
   onHideAll: () => Promise<void>;
   onInvert: () => Promise<void>;
+  listRef?: Ref<HTMLDivElement>;
 }
 
 export interface ChangedElementsListState {
@@ -1310,6 +1313,7 @@ export class ChangedElementsListComponent extends Component<ChangedElementsListP
           pathClicked={this._handlePathClick}
         />
         <ElementsList
+          ref={this.props.listRef}
           nodes={nodes}
           loadNodes={this._loadNodes}
           isLoaded={this._isNodeLoaded}


### PR DESCRIPTION
This change was needed to make it possible for AppUI consumers to fix widget scroll offset failing to restore when switching between widget tabs.

Because consumers are now responsible to fix this AppUI bug themselves, previous changelog entry that mentions this fix has been removed.