### PR TITLE
Place cache directory within test-app-backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 coverage
 lib
 node_modules
+.cache
 
 npm-debug.log*
 pnpm-debug.log*

--- a/packages/test-app-backend/src/main.ts
+++ b/packages/test-app-backend/src/main.ts
@@ -18,6 +18,7 @@ void (async () => {
   Logger.initializeToConsole();
   Logger.setLevelDefault(LogLevel.Info);
   await IModelHost.startup({
+    cacheDir: "./.cache",
     hubAccess: new BackendIModelsAccess(
       new IModelsClient({ api: { baseUrl: `https://${process.env.VITE_URL_PREFIX}api.bentley.com/imodels` } }),
     ),


### PR DESCRIPTION
This cache is supposed to be per-application, but the default cache location can potentially be shared by multiple iTwin.js applications.