### PR TITLE
Fix report dialog not listing any changed properties

### DIFF
--- a/packages/changed-elements-react/CHANGELOG.md
+++ b/packages/changed-elements-react/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased](https://github.com/iTwin/changed-elements-react/tree/HEAD/packages/changed-elements-react)
 
+### Fixes
+
+* Fix `ReportGeneratorDialog` not listing any changed properties.
+
 ## [0.3.2](https://github.com/iTwin/changed-elements-react/tree/v0.3.2/packages/changed-elements-react) - 2023-09-25
 
 ### Patch changes

--- a/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
+++ b/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
@@ -366,17 +366,23 @@ export class ChangedElementsWidget extends Component<ChangedElementsWidgetProps,
             {this.state.loaded ? this.getChangedElementsContent() : this.getLoadingContent()}
           </WidgetComponent.Body>
         </WidgetComponent>
-        <ReportGeneratorDialog
-          isOpen={this.state.reportDialogVisible}
-          onClose={this.closeReportDialog}
-          manager={this.state.manager}
-          initialProperties={this.state.reportProperties}
-        />
-        <VersionCompareSelectDialog
-          iModelConnection={this.props.iModelConnection}
-          isOpen={this.state.versionSelectDialogVisible}
-          onClose={this._handleVersionSelectDialogClose}
-        />
+        {
+          this.state.reportDialogVisible &&
+          <ReportGeneratorDialog
+            isOpen
+            onClose={this.closeReportDialog}
+            manager={this.state.manager}
+            initialProperties={this.state.reportProperties}
+          />
+        }
+        {
+          this.state.versionSelectDialogVisible &&
+          <VersionCompareSelectDialog
+            isOpen
+            iModelConnection={this.props.iModelConnection}
+            onClose={this._handleVersionSelectDialogClose}
+          />
+        }
       </>
     );
   }


### PR DESCRIPTION
`ReportGeneratorDialog` obtains changed properties on component mount and this used to happen before a comparison is started. 

The fix is to mount the component conditionally when user presses the report generator button.