### PR TITLE
Updated comparison job error workflow.

### DIFF
--- a/packages/changed-elements-react/CHANGELOG.md
+++ b/packages/changed-elements-react/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Fixes
 
-* Fixes spurious 409 error in onClick work flow in `ChangedElementsWidget`
+* Fixes comparison job error workflow in `VersionCompareSelectModal`. Error jobs when re-ran will deleted existing broken job and re-run new job for given jobId.
 
 ## [0.6.2](https://github.com/iTwin/changed-elements-react/tree/v0.6.2/packages/changed-elements-react) - 2024-05-15
 

--- a/packages/changed-elements-react/CHANGELOG.md
+++ b/packages/changed-elements-react/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Fixes
 
-* Fixes comparison job error workflow in `VersionCompareSelectModal`. Error jobs when re-ran will delete existing broken job and re-run new job for given jobId.
+* Fixes comparison job error workflow in `VersionCompareSelectModal`. When error jobs are re-run, they delete the existing broken job and re-run a new job for the given job ID.
 
 ## [0.6.2](https://github.com/iTwin/changed-elements-react/tree/v0.6.2/packages/changed-elements-react) - 2024-05-15
 

--- a/packages/changed-elements-react/CHANGELOG.md
+++ b/packages/changed-elements-react/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Fixes
 
-* Fixes comparison job error workflow in `VersionCompareSelectModal`. Error jobs when re-ran will deleted existing broken job and re-run new job for given jobId.
+* Fixes comparison job error workflow in `VersionCompareSelectModal`. Error jobs when re-ran will delete existing broken job and re-run new job for given jobId.
 
 ## [0.6.2](https://github.com/iTwin/changed-elements-react/tree/v0.6.2/packages/changed-elements-react) - 2024-05-15
 

--- a/packages/changed-elements-react/CHANGELOG.md
+++ b/packages/changed-elements-react/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 * Fixes comparison job error workflow in `VersionCompareSelectModal`. When error jobs are re-run, they delete the existing broken job and re-run a new job for the given job ID.
 
+## [0.6.3](https://github.com/iTwin/changed-elements-react/tree/v0.6.3/packages/changed-elements-react) - 2024-05-21
+
+## Fixes
+
+* Fixes spurious 409 error in onClick work flow in `ChangedElementsWidget`
+
 ## [0.6.2](https://github.com/iTwin/changed-elements-react/tree/v0.6.2/packages/changed-elements-react) - 2024-05-15
 
 ## Fixes

--- a/packages/changed-elements-react/package.json
+++ b/packages/changed-elements-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/changed-elements-react",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/changed-elements-react/src/clients/iTwinApi.ts
+++ b/packages/changed-elements-react/src/clients/iTwinApi.ts
@@ -13,7 +13,7 @@ export interface CallITwinApiParams {
   body?: Record<string, unknown> | undefined;
 }
 
-export async function callITwinApi(args: CallITwinApiParams): Promise<Record<string, unknown>> {
+export async function callITwinApi(args: CallITwinApiParams): Promise<Record<string, unknown> |undefined> {
   const response = await fetch(
     args.url,
     {
@@ -31,7 +31,11 @@ export async function callITwinApi(args: CallITwinApiParams): Promise<Record<str
     await throwBadResponseCodeError(response, "iTwin API request failed.");
   }
 
-  return response.json();
+  try {
+    return response.json();
+  } catch (error) {
+    return undefined;
+  }
 }
 
 export async function* callPagedITwinApi(
@@ -41,6 +45,10 @@ export async function* callPagedITwinApi(
   let nextArgs: CallITwinApiParams | undefined = args;
   while (nextArgs) {
     const response = await callITwinApi(nextArgs);
+    if (!response) {
+      nextArgs = undefined;
+      continue;
+    }
     yield response;
     const links = response._links as HalLinks<["prev"?, "next"?]>;
     const nextPageUrl = backwards ? links.prev?.href : links.next?.href;

--- a/packages/changed-elements-react/src/clients/iTwinApi.ts
+++ b/packages/changed-elements-react/src/clients/iTwinApi.ts
@@ -13,7 +13,7 @@ export interface CallITwinApiParams {
   body?: Record<string, unknown> | undefined;
 }
 
-export async function callITwinApi(args: CallITwinApiParams): Promise<Record<string, unknown> |undefined> {
+export async function callITwinApi(args: CallITwinApiParams): Promise<Record<string, unknown> | undefined> {
   const response = await fetch(
     args.url,
     {
@@ -30,12 +30,10 @@ export async function callITwinApi(args: CallITwinApiParams): Promise<Record<str
   if (!response.ok) {
     await throwBadResponseCodeError(response, "iTwin API request failed.");
   }
-
-  try {
+  if (response.status !== 204) {
     return response.json();
-  } catch (error) {
-    return undefined;
   }
+  return undefined;
 }
 
 export async function* callPagedITwinApi(


### PR DESCRIPTION
## Fixes

* Fixes comparison job error workflow in `VersionCompareSelectModal`. When error jobs are re-run, they delete the existing broken job and re-run a new job for the given job ID.