### PR TITLE
Cleanup after `startComparisonV2` failure

### DIFF
--- a/packages/changed-elements-react/CHANGELOG.md
+++ b/packages/changed-elements-react/CHANGELOG.md
@@ -6,9 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased](https://github.com/iTwin/changed-elements-react/tree/HEAD/packages/changed-elements-react)
 
+## Minor changes
+
+* `VersionCompareManager.startComparisonV2`: Invoke `VersionCompareManager.stopComparison` when recovering from error
+
 ## Fixes
 
-* Fixes comparison job error workflow in `VersionCompareSelectModal`. When error jobs are re-run, they delete the existing broken job and re-run a new job for the given job ID.
+* Fix comparison job error workflow in `VersionCompareSelectModal`. When error jobs are re-run, they delete the existing broken job and re-run a new job for the given job ID.
 
 ## [0.6.3](https://github.com/iTwin/changed-elements-react/tree/v0.6.3/packages/changed-elements-react) - 2024-05-21
 

--- a/packages/changed-elements-react/src/api/VersionCompareManager.ts
+++ b/packages/changed-elements-react/src/api/VersionCompareManager.ts
@@ -491,13 +491,17 @@ export class VersionCompareManager {
       IModelApp.notifications.outputMessage(
         new NotifyMessageDetails(OutputMessagePriority.Error, briefError, `${detailed}: ${errorMessage}`),
       );
-      // Notify failure on starting comparison
-      this.versionCompareStartFailed.raiseEvent();
-      this._currentIModel = undefined;
-      this._targetIModel = undefined;
+      try {
+        this.versionCompareStartFailed.raiseEvent();
+      } finally {
+        this._currentIModel = undefined;
+        this._targetIModel = undefined;
 
-      success = false;
-      VersionCompareUtils.outputVerbose(VersionCompareVerboseMessages.versionCompareManagerErrorStarting);
+        success = false;
+        VersionCompareUtils.outputVerbose(VersionCompareVerboseMessages.versionCompareManagerErrorStarting);
+
+        await this.stopComparison();
+      }
     }
 
     return success;

--- a/packages/test-app-frontend/src/App/ITwinJsApp/AppUi/AppUiVisualizationHandler.ts
+++ b/packages/test-app-frontend/src/App/ITwinJsApp/AppUi/AppUiVisualizationHandler.ts
@@ -124,14 +124,12 @@ export class AppUiVisualizationHandler implements VisualizationHandler {
 function bindChangedElementsWidgetEvents(manager: VersionCompareManager): void {
   manager.versionCompareStarting.addListener(onComparisonStarting);
   manager.versionCompareStopped.addListener(onComparisonStopped);
-  manager.versionCompareStartFailed.addListener(onStartFailed);
 }
 
 /** Clean-up events that make the widget automatically react to frontstage activated and version compare events. */
 function unbindChangedElementsWidgetEvents(manager: VersionCompareManager): void {
   manager.versionCompareStarting.removeListener(onComparisonStarting);
   manager.versionCompareStopped.removeListener(onComparisonStopped);
-  manager.versionCompareStartFailed.removeListener(onStartFailed);
 
   // Ensure widget gets closed
   onComparisonStopped();
@@ -146,11 +144,4 @@ function onComparisonStarting(): void {
 
 function onComparisonStopped(): void {
   ChangedElementsListComponent.cleanMaintainedState();
-}
-
-function onStartFailed(): void {
-  // Open/Close comparison legend
-  UiFramework.frontstages.activeFrontstageDef
-    ?.findWidgetDef(ChangedElementsWidget.widgetId)
-    ?.setWidgetState(WidgetState.Hidden);
 }

--- a/packages/test-app-frontend/src/App/ITwinJsApp/AppUi/VersionCompareFrontstageManager.ts
+++ b/packages/test-app-frontend/src/App/ITwinJsApp/AppUi/VersionCompareFrontstageManager.ts
@@ -380,8 +380,7 @@ export class VersionCompareFrontstageManager {
       this._mainViewportState = undefined;
     }
 
-    const changedElementsWidget = frontstageDef.findWidgetDef(ChangedElementsWidget.widgetId);
-    changedElementsWidget?.setWidgetState(this._manager.isComparing ? WidgetState.Open : WidgetState.Hidden);
+    frontstageDef.findWidgetDef(ChangedElementsWidget.widgetId)?.setWidgetState(WidgetState.Open);
   }
 
   /** Stops property comparison */


### PR DESCRIPTION
Also do not hide ChangedElementsWidget on comparison failure in the test app.