### PR TITLE
Fixes Changing to another version is not possible when version compare is already active

### DIFF
--- a/packages/changed-elements-react/CHANGELOG.md
+++ b/packages/changed-elements-react/CHANGELOG.md
@@ -8,7 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Fixes
 
+* `VersionCompareSelectWidget` V2 will now end the active comparison and start a new one once a new one is triggered instead of doing a no-op on starting a new comparison.
+
+## [0.9.1](https://github.com/iTwin/changed-elements-react/tree/v0.9.1/packages/changed-elements-react) - 2024-07-10
+
+## Fixes
+
 * `VersionCompareSelectModal` V2 toast now fixed when opening and closing modal.
+
+## [0.9.0](https://github.com/iTwin/changed-elements-react/tree/v0.9.0/packages/changed-elements-react) - 2024-07-03
+
+## Minor changes
+
+* `VersionCompareFeatureTracking` can now be fed to initialization options
 
 ## [0.8.0](https://github.com/iTwin/changed-elements-react/tree/v0.8.0/packages/changed-elements-react) - 2024-06-28
 

--- a/packages/changed-elements-react/src/widgets/comparisonJobWidget/common/versionCompareV2WidgetUtils.ts
+++ b/packages/changed-elements-react/src/widgets/comparisonJobWidget/common/versionCompareV2WidgetUtils.ts
@@ -23,13 +23,9 @@ export type ManagerStartComparisonV2Args = {
   iModelsClient: IModelsClient;
 };
 
-const handleStopCompare = async (): Promise<void> => {
-  await VersionCompare.manager?.stopComparison();
-};
-
 export const runManagerStartComparisonV2 = async (args: ManagerStartComparisonV2Args) => {
   if (VersionCompare.manager?.isComparing) {
-    await handleStopCompare();
+    await VersionCompare.manager?.stopComparison();
   }
   if (args.getToastsEnabled?.()) {
     toastComparisonVisualizationStarting();

--- a/packages/changed-elements-react/src/widgets/comparisonJobWidget/common/versionCompareV2WidgetUtils.ts
+++ b/packages/changed-elements-react/src/widgets/comparisonJobWidget/common/versionCompareV2WidgetUtils.ts
@@ -23,9 +23,13 @@ export type ManagerStartComparisonV2Args = {
   iModelsClient: IModelsClient;
 };
 
+const handleStopCompare = async (): Promise<void> => {
+  await VersionCompare.manager?.stopComparison();
+};
+
 export const runManagerStartComparisonV2 = async (args: ManagerStartComparisonV2Args) => {
   if (VersionCompare.manager?.isComparing) {
-    return;
+    await handleStopCompare();
   }
   if (args.getToastsEnabled?.()) {
     toastComparisonVisualizationStarting();


### PR DESCRIPTION
Fixed : #1487449