### PR TITLE
Fixed infinite load that would occur with changed element entry look up

### DIFF
--- a/packages/changed-elements-react/CHANGELOG.md
+++ b/packages/changed-elements-react/CHANGELOG.md
@@ -16,10 +16,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 * `VersionCompareSelectWidget` V2 will now end the active comparison and start a new one once a new one is triggered instead of doing a no-op on starting a new comparison.
 
-## Fixes
-
-* `VersionCompareSelectWidget` V2 will now end the active comparison and start a new one once a new one is triggered instead of doing a no-op on starting a new comparison.
-
 ## [0.9.1](https://github.com/iTwin/changed-elements-react/tree/v0.9.1/packages/changed-elements-react) - 2024-07-10
 
 ## Fixes

--- a/packages/changed-elements-react/CHANGELOG.md
+++ b/packages/changed-elements-react/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Fixes
 
+* `ChangedElementEntryCache` Entries will now be compared and loaded based on cached value not, unchanged current value being check. This prevents an infinite loop.
+
+## [0.9.2](https://github.com/iTwin/changed-elements-react/tree/v0.9.2/packages/changed-elements-react) - 2024-07-26
+
+## Fixes
+
+* `VersionCompareSelectWidget` V2 will now end the active comparison and start a new one once a new one is triggered instead of doing a no-op on starting a new comparison.
+
+## Fixes
+
 * `VersionCompareSelectWidget` V2 will now end the active comparison and start a new one once a new one is triggered instead of doing a no-op on starting a new comparison.
 
 ## [0.9.1](https://github.com/iTwin/changed-elements-react/tree/v0.9.1/packages/changed-elements-react) - 2024-07-10

--- a/packages/changed-elements-react/src/api/ChangedElementEntryCache.ts
+++ b/packages/changed-elements-react/src/api/ChangedElementEntryCache.ts
@@ -177,7 +177,7 @@ export class ChangedElementEntryCache {
    * @returns True if loaded
    */
   public isLoaded = (entry: ChangedElementEntry) => {
-    const cachedNode =this.changedElementEntries.get(entry.id);
+    const cachedNode = this.changedElementEntries.get(entry.id);
     return (
       cachedNode !== undefined &&
       cachedNode.loaded &&

--- a/packages/changed-elements-react/src/api/ChangedElementEntryCache.ts
+++ b/packages/changed-elements-react/src/api/ChangedElementEntryCache.ts
@@ -177,10 +177,12 @@ export class ChangedElementEntryCache {
    * @returns True if loaded
    */
   public isLoaded = (entry: ChangedElementEntry) => {
+    const cachedNode =this.changedElementEntries.get(entry.id);
     return (
-      entry.loaded &&
-      entry.directChildren !== undefined &&
-      entry.label !== undefined
+      cachedNode !== undefined &&
+      cachedNode.loaded &&
+      cachedNode.directChildren !== undefined &&
+      cachedNode.label !== undefined
     );
   };
 


### PR DESCRIPTION
We should have been doing a cache look-up. We passed an unloaded change elements entry, which was cached as loaded. So we would see the unloaded entry and return unloaded and try to load it. Then load it cache we loaded it. Then check if it was loaded and then get back unloaded bc we passed in an unloaded entry to check ...

Fixed by using cached value instead