### PR TITLE
Fix console warnings in development environment

### DIFF
--- a/packages/changed-elements-react/CHANGELOG.md
+++ b/packages/changed-elements-react/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Fixes
 
+* Fix the following console warnings in development environment
+  * Receiving invalid property when mounting `<ChangedElementsWidget />` with V2 version selector
+  * Receiving invalid list ref when displaying changed elements list
+  * `checked` checkbox property not being accompanied by `onChange` event handler when rendering element filters popup
 * Fixed color issues for feedback btn text
 
 ## [0.11.1](https://github.com/iTwin/changed-elements-react/tree/v0.11.1/packages/changed-elements-react) - 2024-10-16

--- a/packages/changed-elements-react/src/AutoSizer.tsx
+++ b/packages/changed-elements-react/src/AutoSizer.tsx
@@ -3,9 +3,10 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import {
-  forwardRef, useLayoutEffect, useRef, useState, type ForwardedRef, type HTMLAttributes, type ReactNode,
-  type RefCallback
+  forwardRef, useLayoutEffect, useMemo, useRef, useState, type HTMLAttributes, type ReactNode
 } from "react";
+
+import { mergeRefs } from "./common.js";
 
 export interface AutoSizerProps extends HTMLAttributes<HTMLDivElement> {
   children: (size: Size) => ReactNode;
@@ -35,18 +36,7 @@ export const AutoSizer = forwardRef<HTMLDivElement, AutoSizerProps>(
       [],
     );
 
-    return <div ref={mergeRefs(divRef, ref)} className={props.className}>{size && props.children(size)}</div>;
+    const mergedRefs = useMemo(() => mergeRefs(divRef, ref), [divRef, ref]);
+    return <div ref={mergedRefs} className={props.className}>{size && props.children(size)}</div>;
   },
 );
-
-function mergeRefs<T>(...refs: Array<ForwardedRef<T>>): RefCallback<T> {
-  return (value) => {
-    refs.forEach((ref) => {
-      if (typeof ref === "function") {
-        ref(value);
-      } else if (ref) {
-        ref.current = value;
-      }
-    });
-  };
-}

--- a/packages/changed-elements-react/src/common.ts
+++ b/packages/changed-elements-react/src/common.ts
@@ -2,9 +2,23 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
+import type { ForwardedRef, RefCallback } from "react";
 
 /** Models BeEvent class interface. */
 export interface EventEmitter<T extends (...arg: unknown[]) => void> {
   addListener(eventListener: T): void;
   removeListener(eventListener: T): void;
+}
+
+/** Merges multiple React refs into one. */
+export function mergeRefs<T>(...refs: Array<ForwardedRef<T>>): RefCallback<T> {
+  return (value) => {
+    refs.forEach((ref) => {
+      if (typeof ref === "function") {
+        ref(value);
+      } else if (ref) {
+        ref.current = value;
+      }
+    });
+  };
 }

--- a/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.tsx
+++ b/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.tsx
@@ -93,7 +93,7 @@ export function PropertyComparisonTable(props: PropertyComparisonTableProps): Re
         }
         <div className="settings">
           {
-            (displaySideBySideToggle ?? true) &&
+            (displaySideBySideToggle ?? props.onSideBySideToggle) &&
             <SideBySideToggle
               manager={manager}
               selection={selection}

--- a/packages/changed-elements-react/src/widgets/ElementsList.tsx
+++ b/packages/changed-elements-react/src/widgets/ElementsList.tsx
@@ -10,6 +10,7 @@ import { FixedSizeList } from "react-window";
 import InfiniteLoader from "react-window-infinite-loader";
 
 import { AutoSizer } from "../AutoSizer.js";
+import { mergeRefs } from "../common.js";
 import { ElementNodeComponent } from "./ElementNodeComponent.js";
 
 import "./ChangedElementsInspector.scss";
@@ -180,10 +181,10 @@ export const ElementsList = forwardRef<HTMLDivElement, ElementsListProps>(
               itemCount={props.nodes.length}
               loadMoreItems={loadMoreItems}
             >
-              {({ onItemsRendered }) => {
+              {({ onItemsRendered, ref }) => {
                 return (
                   <FixedSizeList
-                    ref={listRef}
+                    ref={mergeRefs(ref, listRef)}
                     style={{ overflow: "overlay" }}
                     height={size.height}
                     itemCount={props.nodes.length}

--- a/packages/changed-elements-react/src/widgets/EnhancedElementsInspector.tsx
+++ b/packages/changed-elements-react/src/widgets/EnhancedElementsInspector.tsx
@@ -338,7 +338,7 @@ function ChangeTypeFilterHeader(props: FilterHeaderProps): ReactElement {
           key={localeStr}
           label={IModelApp.localization.getLocalizedString(`VersionCompare:typeOfChange.${localeStr}`)}
           checked={isOn}
-          onClick={() => {
+          onChange={() => {
             const opts = props.options;
             opts.wantedTypeOfChange = isOn ? opts.wantedTypeOfChange & ~flag : opts.wantedTypeOfChange | flag;
             props.onFilterChange(opts);

--- a/packages/changed-elements-react/src/widgets/InformationButton.tsx
+++ b/packages/changed-elements-react/src/widgets/InformationButton.tsx
@@ -22,7 +22,6 @@ function InfoButton(props: Props) {
     <DropdownMenu
       style={{ width: 500 }}
       placement="bottom-end"
-      data-testid={props["data-testid"]}
       menuItems={() => [
         <MenuExtraContent key={0}>
           <Text variant="leading">{props.title}</Text>
@@ -30,7 +29,11 @@ function InfoButton(props: Props) {
         </MenuExtraContent>,
       ]}
     >
-      <IconButton styleType="borderless" aria-label="Information">
+      <IconButton
+        data-testid={props["data-testid"]}
+        styleType="borderless"
+        aria-label="Information"
+      >
         <SvgInfo />
       </IconButton>
     </DropdownMenu>


### PR DESCRIPTION
## Fixes

* Fix the following console warnings in development environment
  * Receiving invalid property when mounting `<ChangedElementsWidget />` with V2 version selector
  * Receiving invalid list ref when displaying changed elements list
  * `checked` checkbox property not being accompanied by `onChange` event handler when rendering element filters popup