### PR TITLE
Updated CI not to run changeset status if user is imodeljs-admin

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -43,6 +43,7 @@ jobs:
       run: pnpm audit --audit-level high
 
     - name: Check if changeset is present
+      if: github.actor != 'imodeljs-admin'
       run: |
         # There are issues with changesets in github workflows, so we need to force pull the master branch
         # Fix for issue https://github.com/changesets/changesets/issues/517#issuecomment-884778604


### PR DESCRIPTION
The only PRs the admin user creates are for releases and should not need the changeset status check.