### PR TITLE
Updated build pipeline with directed build

### DIFF
--- a/.changeset/rare-peaches-double.md
+++ b/.changeset/rare-peaches-double.md
@@ -1,0 +1,18 @@
+---
+"@itwin/changed-elements-react": minor
+---
+
+- Added experimental React component for the new Named Version selector. Its name or API is not stable yet, but you can try it out the following way.
+
+  ```TypeScript
+  import { NamedVersionSelectorWidget } from "@itwin/changed-elements-react/experimental";
+
+  [...]
+
+    return (
+      <VersionCompareContext iModelsClient={iModelsClient}>
+        <NamedVersionSelectorWidget iModel={iModel} />
+      </VersionCompareContext>
+    );
+  }
+  ```

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -46,11 +46,16 @@ jobs:
     - name: Run Audit
       run: pnpm audit --audit-level high
 
+    - name: Build components
+      run: |
+        cd packages/changed-elements-react &&
+        pnpm run build
+
     - name: Create release PR or publish to npm
       id: changesets
       uses: changesets/action@v1
       with:
-        publish: pnpm run build:components && pnpm changeset publish
+        publish: pnpm changeset publish
         title: Release packages [publish docs]
         commit: Release packages [publish docs]
         createGithubReleases: true

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "typecheck:components": "npm run typecheck --prefix packages/changed-elements-react",
     "typecheck:backend": "npm run typecheck --prefix packages/test-app-backend",
     "typecheck:frontend": "npm run typecheck --prefix packages/test-app-frontend",
-    "check": "changeset status",
-    "build:components": "pnpm build --prefix packages/changed-elements-react"
+    "check": "changeset status"
   },
   "engines": {
     "pnpm": ">=8",

--- a/packages/changed-elements-react/CHANGELOG.md
+++ b/packages/changed-elements-react/CHANGELOG.md
@@ -1,26 +1,5 @@
 # Changelog
 
-## 0.12.0
-
-### Minor Changes
-
-#### [0.12.0](https://github.com/iTwin/changed-elements-react/tree/v0.12.0/packages/changed-elements-react) - 2025-01-21
-
-- Added experimental React component for the new Named Version selector. Its name or API is not stable yet, but you can try it out the following way.
-
-  ```TypeScript
-  import { NamedVersionSelectorWidget } from "@itwin/changed-elements-react/experimental";
-
-  [...]
-
-    return (
-      <VersionCompareContext iModelsClient={iModelsClient}>
-        <NamedVersionSelectorWidget iModel={iModel} />
-      </VersionCompareContext>
-    );
-  }
-  ```
-
 ## 0.11.4
 
 ### Patch Changes

--- a/packages/changed-elements-react/package.json
+++ b/packages/changed-elements-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/changed-elements-react",
-  "version": "0.12.0",
+  "version": "0.11.4",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The build step failed in publishing, preventing the release. Now, the build is pointed to the correct directory and runs before release.
Reverted release PR changes.

Fixes :
![image](https://github.com/user-attachments/assets/1176030d-0fc7-43a3-9d43-06308304b10d)
