### PR TITLE
Fix for named version loader pane list item size and added feedback button

### DIFF
--- a/.changeset/breezy-cherries-compete.md
+++ b/.changeset/breezy-cherries-compete.md
@@ -3,3 +3,17 @@
 ---
 
 Added a feedback button to the experimental UI and fixed the spacing on named versions in the new widget list.
+Import moved for experimental UI. As previous way of importing did not work.
+Marked new component as a alpha and and subject to change.
+  ```TypeScript
+  import { NamedVersionSelectorWidget } from "@itwin/changed-elements-react";
+
+  [...]
+
+    return (
+      <VersionCompareContext iModelsClient={iModelsClient}>
+        <NamedVersionSelectorWidget iModel={iModel} />
+      </VersionCompareContext>
+    );
+  }
+  ```

--- a/.changeset/breezy-cherries-compete.md
+++ b/.changeset/breezy-cherries-compete.md
@@ -1,0 +1,5 @@
+---
+"@itwin/changed-elements-react": patch
+---
+
+Added a feedback button to the experimental UI and fixed the spacing on named versions in the new widget list.

--- a/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.css
+++ b/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.css
@@ -103,11 +103,10 @@
     }
 
     ._cer_v1_named-version-entry {
-      min-height: min-content;
+      min-height: calc(3 * var(--iui-size-xl));
       padding-block: var(--iui-size-m);
       border: 1px solid var(--iui-color-border-subtle);
       border-radius: 0;
-
       display: grid;
       gap: unset;
       grid-template-columns: subgrid;

--- a/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.css
+++ b/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.css
@@ -108,7 +108,7 @@
     }
 
     ._cer_v1_named-version-entry {
-      min-height: 7rem;
+      min-height: var(--iui-size-3xl);
       padding-block: var(--iui-size-m);
       border: 1px solid var(--iui-color-border-subtle);
       border-radius: 0;

--- a/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.css
+++ b/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.css
@@ -34,6 +34,11 @@
       }
     }
 
+    ._cer_v1_feedback_btn_container {
+      margin-top: auto;
+      text-align: center
+    }
+
     ._cer_v1_active-versions-box {
       min-width: min-content;
       padding: var(--iui-size-s);
@@ -103,7 +108,7 @@
     }
 
     ._cer_v1_named-version-entry {
-      min-height: calc(3 * var(--iui-size-xl));
+      min-height: 7rem;
       padding-block: var(--iui-size-m);
       border: 1px solid var(--iui-color-border-subtle);
       border-radius: 0;

--- a/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.css
+++ b/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.css
@@ -100,13 +100,6 @@
       > * {
         padding-inline: var(--_cer_v1_container-margin-internal);
       }
-      > :last-child {
-        margin-top: 20px;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        grid-column: 1 / -1; /* Ensure it spans all columns */
-      }
     }
 
     ._cer_v1_named-version-entry {

--- a/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.css
+++ b/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.css
@@ -100,6 +100,13 @@
       > * {
         padding-inline: var(--_cer_v1_container-margin-internal);
       }
+      > :last-child {
+        margin-top: 20px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        grid-column: 1 / -1; /* Ensure it spans all columns */
+      }
     }
 
     ._cer_v1_named-version-entry {

--- a/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
+++ b/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
@@ -49,6 +49,7 @@ interface NamedVersionSelectorWidgetProps {
 /**
  * By default, displays Named Version selector, but when {@link VersionCompareManager}
  * is actively comparing versions, presents the comparison results.
+ * @alpha feature is experimental and may change in future releases.
  */
 export function NamedVersionSelectorWidget(props: NamedVersionSelectorWidgetProps): ReactElement {
   const manager = props.manager ?? VersionCompare.manager;

--- a/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
+++ b/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
@@ -79,13 +79,13 @@ export function NamedVersionSelectorWidget(props: NamedVersionSelectorWidgetProp
 
   if (!isComparing) {
     return (
-      <NamedVersionSelector
-        iModel={iModel}
-        manager={manager}
-        emptyState={emptyState}
-        manageVersions={manageVersions}
-        feedbackUrl={feedbackUrl}
-      />
+        <NamedVersionSelector
+          iModel={iModel}
+          manager={manager}
+          emptyState={emptyState}
+          manageVersions={manageVersions}
+          feedbackUrl={feedbackUrl}
+        />
     );
   }
 
@@ -216,10 +216,12 @@ function NamedVersionSelector(props: NamedVersionSelectorProps): ReactElement {
               updateJobStatus={updateJobStatus}
               emptyState={emptyState}
               manageVersions={manageVersions}
-              feedbackUrl={feedbackUrl}
             />
           )
       }
+      <div className="_cer_v1_feedback_btn_container">
+        {feedbackUrl && <FeedbackButton feedbackUrl={feedbackUrl} />}
+      </div>
     </Widget>
   );
 }
@@ -334,7 +336,6 @@ interface NamedVersionSelectorLoadedProps {
   onNamedVersionOpened: (version: NamedVersionEntry) => void;
   emptyState?: ReactNode | undefined;
   manageVersions?: ReactNode | undefined;
-  feedbackUrl?: string | undefined;
 }
 
 function NamedVersionSelectorLoaded(props: NamedVersionSelectorLoadedProps): ReactElement {
@@ -348,7 +349,6 @@ function NamedVersionSelectorLoaded(props: NamedVersionSelectorLoadedProps): Rea
     onNamedVersionOpened,
     emptyState,
     manageVersions,
-    feedbackUrl,
   } = props;
 
   const { queryJobStatus, startJob } = useComparisonJobs({
@@ -454,7 +454,6 @@ function NamedVersionSelectorLoaded(props: NamedVersionSelectorLoadedProps): Rea
   }
 
   return (
-    <>
       <List className="_cer_v1_named-version-list">
         <Sticky className="_cer_v1_named-version-list-header">
           <TextEx weight="semibold">
@@ -472,10 +471,6 @@ function NamedVersionSelectorLoaded(props: NamedVersionSelectorLoadedProps): Rea
           }
         </namedVersionSelectorContext.Provider>
       </List>
-      <div>
-        {feedbackUrl ? <FeedbackButton feedbackUrl={feedbackUrl} /> : <></>}
-      </div>
-    </>
   );
 }
 

--- a/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
+++ b/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
@@ -36,12 +36,14 @@ import {
 import { useQueue } from "./useQueue.js";
 
 import "./NamedVersionSelector.css";
+import { FeedbackButton } from "../widgets/FeedbackButton.js";
 
 interface NamedVersionSelectorWidgetProps {
   iModel: IModelConnection;
   manager?: VersionCompareManager | undefined;
   emptyState?: ReactNode | undefined;
   manageVersions?: ReactNode | undefined;
+  feedbackUrl?: string | undefined;
 }
 
 /**
@@ -54,7 +56,7 @@ export function NamedVersionSelectorWidget(props: NamedVersionSelectorWidgetProp
     throw new Error("VersionCompare is not initialized.");
   }
 
-  const { iModel, emptyState, manageVersions } = props;
+  const { iModel, emptyState, manageVersions , feedbackUrl } = props;
 
   const [isComparing, setIsComparing] = useState(manager.isComparing);
 
@@ -82,6 +84,7 @@ export function NamedVersionSelectorWidget(props: NamedVersionSelectorWidgetProp
         manager={manager}
         emptyState={emptyState}
         manageVersions={manageVersions}
+        feedbackUrl={feedbackUrl}
       />
     );
   }
@@ -115,6 +118,7 @@ export function NamedVersionSelectorWidget(props: NamedVersionSelectorWidgetProp
               ref={widgetRef}
               iModelConnection={iModel}
               manager={manager}
+              feedbackUrl={feedbackUrl}
             />
           </namedVersionSelectorContext.Provider>
         )}
@@ -128,6 +132,7 @@ interface NamedVersionSelectorProps {
   manager: VersionCompareManager;
   emptyState?: ReactNode | undefined;
   manageVersions?: ReactNode | undefined;
+  feedbackUrl?: string | undefined;
 }
 
 function NamedVersionSelector(props: NamedVersionSelectorProps): ReactElement {
@@ -136,7 +141,7 @@ function NamedVersionSelector(props: NamedVersionSelectorProps): ReactElement {
     throw new Error("V2 Client is not initialized in given context.");
   }
 
-  const { iModel, manager, emptyState, manageVersions } = props;
+  const { iModel, manager, emptyState, manageVersions, feedbackUrl } = props;
 
   const iTwinId = iModel.iTwinId as string;
   const iModelId = iModel.iModelId as string;
@@ -212,6 +217,7 @@ function NamedVersionSelector(props: NamedVersionSelectorProps): ReactElement {
               updateJobStatus={updateJobStatus}
               emptyState={emptyState}
               manageVersions={manageVersions}
+              feedbackUrl={feedbackUrl}
             />
           )
       }
@@ -329,6 +335,7 @@ interface NamedVersionSelectorLoadedProps {
   onNamedVersionOpened: (version: NamedVersionEntry) => void;
   emptyState?: ReactNode | undefined;
   manageVersions?: ReactNode | undefined;
+  feedbackUrl?: string | undefined;
 }
 
 function NamedVersionSelectorLoaded(props: NamedVersionSelectorLoadedProps): ReactElement {
@@ -342,6 +349,7 @@ function NamedVersionSelectorLoaded(props: NamedVersionSelectorLoadedProps): Rea
     onNamedVersionOpened,
     emptyState,
     manageVersions,
+    feedbackUrl,
   } = props;
 
   const { queryJobStatus, startJob } = useComparisonJobs({
@@ -463,6 +471,9 @@ function NamedVersionSelectorLoaded(props: NamedVersionSelectorLoadedProps): Rea
           ))
         }
       </namedVersionSelectorContext.Provider>
+      <div>
+        {feedbackUrl ? <FeedbackButton feedbackUrl={feedbackUrl} /> : <></>}
+      </div>
     </List>
   );
 }

--- a/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
+++ b/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
@@ -118,7 +118,6 @@ export function NamedVersionSelectorWidget(props: NamedVersionSelectorWidgetProp
               ref={widgetRef}
               iModelConnection={iModel}
               manager={manager}
-              feedbackUrl={feedbackUrl}
             />
           </namedVersionSelectorContext.Provider>
         )}
@@ -455,26 +454,28 @@ function NamedVersionSelectorLoaded(props: NamedVersionSelectorLoadedProps): Rea
   }
 
   return (
-    <List className="_cer_v1_named-version-list">
-      <Sticky className="_cer_v1_named-version-list-header">
-        <TextEx weight="semibold">
-          {t("VersionCompare:versionCompare.previousVersions")}
-        </TextEx>
-        {manageVersions}
-      </Sticky>
-      <namedVersionSelectorContext.Provider
-        value={{ processResults, viewResults, initialLoad, checkStatus }}
-      >
-        {
-          props.entries.map((entry) => (
-            <NamedVersionListEntry key={entry.namedVersion.id} entry={entry} />
-          ))
-        }
-      </namedVersionSelectorContext.Provider>
+    <>
+      <List className="_cer_v1_named-version-list">
+        <Sticky className="_cer_v1_named-version-list-header">
+          <TextEx weight="semibold">
+            {t("VersionCompare:versionCompare.previousVersions")}
+          </TextEx>
+          {manageVersions}
+        </Sticky>
+        <namedVersionSelectorContext.Provider
+          value={{ processResults, viewResults, initialLoad, checkStatus }}
+        >
+          {
+            props.entries.map((entry) => (
+              <NamedVersionListEntry key={entry.namedVersion.id} entry={entry} />
+            ))
+          }
+        </namedVersionSelectorContext.Provider>
+      </List>
       <div>
         {feedbackUrl ? <FeedbackButton feedbackUrl={feedbackUrl} /> : <></>}
       </div>
-    </List>
+    </>
   );
 }
 

--- a/packages/changed-elements-react/src/index.ts
+++ b/packages/changed-elements-react/src/index.ts
@@ -37,3 +37,4 @@ export type {
 } from "./widgets/comparisonJobWidget/models/ComparisonJobModels.js";
 export { ChangedElementsListComponent } from "./widgets/EnhancedElementsInspector.js";
 export * from "./widgets/VersionCompareSelectWidget.js";
+export { NamedVersionSelectorWidget } from "./NamedVersionSelector/NamedVersionSelector.js";

--- a/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
+++ b/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
@@ -380,7 +380,7 @@ export class ChangedElementsWidget extends Component<ChangedElementsWidgetProps,
             }
           </WidgetComponent.Body>
           {
-            this.props.useV2Widget && this.props.feedbackUrl &&
+            this.props.feedbackUrl &&
             <WidgetComponent.ToolBar>
               <FeedbackButton
                 data-testid="comparison-widget-v2-feedback-btn"

--- a/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
+++ b/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
@@ -380,7 +380,7 @@ export class ChangedElementsWidget extends Component<ChangedElementsWidgetProps,
             }
           </WidgetComponent.Body>
           {
-            this.props.feedbackUrl &&
+            this.props.useV2Widget && this.props.feedbackUrl &&
             <WidgetComponent.ToolBar>
               <FeedbackButton
                 data-testid="comparison-widget-v2-feedback-btn"

--- a/packages/changed-elements-react/src/widgets/FeedbackButton.scss
+++ b/packages/changed-elements-react/src/widgets/FeedbackButton.scss
@@ -5,7 +5,7 @@
 
 .changed-elems-feedback-btn {
   width: fit-content;
-  margin: 0 auto 0px;
+  margin: 0 auto 10px;
   overflow: hidden;
   border-radius: 50px;
   display: flex;

--- a/packages/changed-elements-react/src/widgets/FeedbackButton.scss
+++ b/packages/changed-elements-react/src/widgets/FeedbackButton.scss
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 .changed-elems-feedback-btn {
-  margin: 0 auto 50px;
+  margin: 0 auto 0px;
   overflow: hidden;
   border-radius: 50px;
   display: flex;

--- a/packages/changed-elements-react/src/widgets/FeedbackButton.scss
+++ b/packages/changed-elements-react/src/widgets/FeedbackButton.scss
@@ -4,6 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 .changed-elems-feedback-btn {
+  width: fit-content;
   margin: 0 auto 0px;
   overflow: hidden;
   border-radius: 50px;

--- a/packages/test-app-frontend/src/App/ITwinJsApp/ITwinJsApp.tsx
+++ b/packages/test-app-frontend/src/App/ITwinJsApp/ITwinJsApp.tsx
@@ -313,6 +313,7 @@ class MainFrontstageItemsProvider implements UiItemsProvider {
               iModel={iModel}
               manager={VersionCompare.manager}
               manageVersions={<ManageNamedVersions />}
+              feedbackUrl="https://example.com"
             />
           ),
         },

--- a/packages/test-app-frontend/src/App/ITwinJsApp/ITwinJsApp.tsx
+++ b/packages/test-app-frontend/src/App/ITwinJsApp/ITwinJsApp.tsx
@@ -303,7 +303,7 @@ class MainFrontstageItemsProvider implements UiItemsProvider {
       return [];
     }
 
-    if (!runExperimental) {
+    if (runExperimental) {
       return [
         {
           id: "NamedVersionSelector",

--- a/packages/test-app-frontend/src/App/ITwinJsApp/ITwinJsApp.tsx
+++ b/packages/test-app-frontend/src/App/ITwinJsApp/ITwinJsApp.tsx
@@ -11,9 +11,9 @@ import {
 import {
   ChangedElementsWidget,
   ComparisonJobClient, ITwinIModelsClient, VersionCompare, VersionCompareContext,
-  VersionCompareFeatureTracking
+  VersionCompareFeatureTracking,
+  NamedVersionSelectorWidget
 } from "@itwin/changed-elements-react";
-import { NamedVersionSelectorWidget } from "@itwin/changed-elements-react/experimental";
 import { Id64 } from "@itwin/core-bentley";
 import {
   AuthorizationClient, BentleyCloudRpcManager, BentleyCloudRpcParams, IModelReadRpcInterface, IModelTileRpcInterface

--- a/packages/test-app-frontend/src/environment.ts
+++ b/packages/test-app-frontend/src/environment.ts
@@ -26,6 +26,6 @@ export function applyUrlPrefix(base: string, url = ""): string {
 
 export const clientId: string = import.meta.env.VITE_CLIENT_ID;
 export const urlPrefix: string = import.meta.env.VITE_URL_PREFIX;
-export const runExperimental: boolean = import.meta.env.VITE_RUN_EXPERIMENTAL;
+export const runExperimental: boolean = import.meta.env.VITE_RUN_EXPERIMENTAL === "true";
 export const usingLocalBackend: boolean = import.meta.env.VITE_USE_LOCAL_BACKEND === "true";
 export const localBackendPort: number = Number.parseInt(import.meta.env.VITE_LOCAL_BACKEND_PORT, 10);


### PR DESCRIPTION
List items were overlapping with each other:
![image](https://github.com/user-attachments/assets/a5fdcecf-3103-46c4-8748-b1b034b4c394)

Now, they are not, and added feedback button :

![image](https://github.com/user-attachments/assets/1c25d1eb-a0ee-474f-9c99-2c2d869f9676)

