### PR TITLE
Updated Params for onJobUpdate

### DIFF
--- a/.changeset/thin-news-matter.md
+++ b/.changeset/thin-news-matter.md
@@ -1,0 +1,30 @@
+---
+"@itwin/changed-elements-react": minor
+---
+
+```
+export type V2DialogProviderProps = {
+  children: React.ReactNode;
+  // Optional. When enabled will toast messages regarding job status. If not defined will default to false and will not show toasts.
+  enableComparisonJobUpdateToasts?: boolean;
+  /** On Job Update
+ * Optional. a call back function for handling job updates.
+ * @param comparisonJobUpdateType param for the type of update:
+ *  - "JobComplete" = invoked when job is completed
+ *  - "JobError" = invoked on job error
+ *  - "JobProcessing" = invoked on job is started
+ *  - "ComparisonVisualizationStarting" = invoked on when version compare visualization is starting
+ * @param toaster from iTwin Ui's useToaster hook. This is necessary for showing toast messages.
+ * @param jobAndNamedVersion param contain job and named version info to be passed to call back
+*/
+  onJobUpdate?: (comparisonJobUpdateType: ComparisonJobUpdateType, toaster: ReturnType<typeof useToaster> ,jobAndNamedVersions?: JobAndNamedVersions) => Promise<void>;
+};
+```
+
+Toaster is no longer an exported member from iTwin UI 3.x.x. UseToaster is now required to be called in the callee of V2Dialog for onJobUpdate.
+
+```
+import { useToaster } from "@itwin/itwinui-react";
+const toaster = useToaster();
+onJobUpdate(comparisonEventType, toaster, jobAndNamedVersions);
+```

--- a/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
+++ b/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
@@ -78,6 +78,7 @@ export interface ChangedElementsWidgetProps {
    *  - "JobError" = invoked on job error
    *  - "JobProgressing" = invoked on job is started
    *  - "ComparisonVisualizationStarting" = invoked on when version compare visualization is starting
+   * @param toaster from iTwin Ui's useToaster hook. This is necessary for showing toast messages.
    * @param jobAndNamedVersion param contain job and named version info to be passed to call back
    */
   onJobUpdate?: (

--- a/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
+++ b/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
@@ -7,7 +7,7 @@ import {
   IModelApp, NotifyMessageDetails, OutputMessagePriority, type IModelConnection, type ScreenViewport
 } from "@itwin/core-frontend";
 import { SvgAdd, SvgCompare, SvgExport, SvgStop } from "@itwin/itwinui-icons-react";
-import { IconButton, ProgressRadial, Text } from "@itwin/itwinui-react";
+import { IconButton, ProgressRadial, Text, useToaster } from "@itwin/itwinui-react";
 import { Component, type ReactElement, type ReactNode } from "react";
 
 import { namedVersionSelectorContext } from "../NamedVersionSelector/NamedVersionSelectorContext.js";
@@ -82,6 +82,7 @@ export interface ChangedElementsWidgetProps {
    */
   onJobUpdate?: (
     comparisonJobUpdateType: ComparisonJobUpdateType,
+    toaster: ReturnType<typeof useToaster>,
     jobAndNamedVersions?: JobAndNamedVersions,
   ) => Promise<void>;
 

--- a/packages/changed-elements-react/src/widgets/comparisonJobWidget/components/VersionCompareDialogProvider.tsx
+++ b/packages/changed-elements-react/src/widgets/comparisonJobWidget/components/VersionCompareDialogProvider.tsx
@@ -5,6 +5,7 @@
 import React from "react";
 
 import type { JobAndNamedVersions } from "../models/ComparisonJobModels.js";
+import { useToaster } from "@itwin/itwinui-react";
 
 /** Comparison Job Update Type
 *  - "JobComplete" = job is completed
@@ -41,9 +42,10 @@ export type V2DialogProviderProps = {
  *  - "JobError" = invoked on job error
  *  - "JobProcessing" = invoked on job is started
  *  - "ComparisonVisualizationStarting" = invoked on when version compare visualization is starting
+ * @param toaster from iTwin Ui's useToaster hook. This is necessary for showing toast messages.
  * @param jobAndNamedVersion param contain job and named version info to be passed to call back
 */
-  onJobUpdate?: (comparisonJobUpdateType: ComparisonJobUpdateType, jobAndNamedVersions?: JobAndNamedVersions) => Promise<void>;
+  onJobUpdate?: (comparisonJobUpdateType: ComparisonJobUpdateType, toaster: ReturnType<typeof useToaster> ,jobAndNamedVersions?: JobAndNamedVersions) => Promise<void>;
 };
 
 /** V2DialogProvider use comparison jobs for processing.
@@ -60,6 +62,7 @@ export type V2DialogProviderProps = {
  *</V2DialogProvider>
 */
 export function VersionCompareSelectProviderV2({ children, enableComparisonJobUpdateToasts, onJobUpdate }: V2DialogProviderProps) {
+  const toaster = useToaster();
   const dialogRunningJobs = React.useRef<Map<string, JobAndNamedVersions>>(new Map<string, JobAndNamedVersions>());
   const dialogPendingJobs = React.useRef<Map<string, JobAndNamedVersions>>(new Map<string, JobAndNamedVersions>());
   const addRunningJob = (jobId: string, jobAndNamedVersions: JobAndNamedVersions) => {
@@ -103,7 +106,7 @@ export function VersionCompareSelectProviderV2({ children, enableComparisonJobUp
   };
   const runOnJobUpdate = async (comparisonEventType: ComparisonJobUpdateType, jobAndNamedVersions?: JobAndNamedVersions) => {
     if (onJobUpdate) {
-      void onJobUpdate(comparisonEventType, jobAndNamedVersions);
+      void onJobUpdate(comparisonEventType, toaster, jobAndNamedVersions);
     }
   };
   return (


### PR DESCRIPTION
```
export type V2DialogProviderProps = {
  children: React.ReactNode;
  // Optional. When enabled will toast messages regarding job status. If not defined will default to false and will not show toasts.
  enableComparisonJobUpdateToasts?: boolean;
  /** On Job Update
 * Optional. a call back function for handling job updates.
 * @param comparisonJobUpdateType param for the type of update:
 *  - "JobComplete" = invoked when job is completed
 *  - "JobError" = invoked on job error
 *  - "JobProcessing" = invoked on job is started
 *  - "ComparisonVisualizationStarting" = invoked on when version compare visualization is starting
 * @param toaster from iTwin Ui's useToaster hook. This is necessary for showing toast messages.
 * @param jobAndNamedVersion param contain job and named version info to be passed to call back
*/
  onJobUpdate?: (comparisonJobUpdateType: ComparisonJobUpdateType, toaster: ReturnType<typeof useToaster> ,jobAndNamedVersions?: JobAndNamedVersions) => Promise<void>;
};
```

Toaster is no longer an exported member from iTwin UI 3.x.x. UseToaster is now required to be called in the callee of V2Dialog for onJobUpdate.

```
import { useToaster } from "@itwin/itwinui-react";
const toaster = useToaster();
onJobUpdate(comparisonEventType, toaster, jobAndNamedVersions);
```
