### PR TITLE
Fixes NamedVersionSelectorWidget showing loading when no named version present and fixes default dialog being shown for new widget

### DIFF
--- a/.changeset/bright-cougars-bathe.md
+++ b/.changeset/bright-cougars-bathe.md
@@ -1,0 +1,7 @@
+---
+"@itwin/changed-elements-react": patch
+---
+
+-Fixes NamedVersionSelectorWidget showing loading and spinning forever when no named version present.
+
+-Fixes default dialog being shown for NamedVersionSelectorWidget when comparison is started. Now we show the proper loading state with spinner instead of "no comparison loaded".

--- a/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
+++ b/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
@@ -349,11 +349,9 @@ function NamedVersionSelectorLoaded(props: NamedVersionSelectorLoadedProps): Rea
     iTwinId,
     iModelId,
     currentNamedVersion,
-    isLoading,
     entries,
     updateJobStatus,
     onNamedVersionOpened,
-    emptyState,
     manageVersions,
   } = props;
 

--- a/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
+++ b/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
@@ -198,6 +198,11 @@ function NamedVersionSelector(props: NamedVersionSelectorProps): ReactElement {
         <ActiveVersionsBox current={currentNamedVersion} selected={openedVersion} />
       }
       {
+        (!isLoading && entries.length === 0)?
+          <Text className="_cer_v1_empty-state" isMuted>
+            {t("VersionCompare:versionCompare.noPreviousVersionAvailable")}
+          </Text>
+          :
         (!currentNamedVersion || (isLoading && entries.length === 0))
           ? (
             <LoadingContent>
@@ -441,18 +446,6 @@ function NamedVersionSelectorLoaded(props: NamedVersionSelectorLoadedProps): Rea
       [queryStatus],
     ),
   );
-
-  if (!isLoading && entries.length === 0) {
-    if (emptyState) {
-      return <>{emptyState}</>;
-    }
-
-    return (
-      <Text className="_cer_v1_empty-state" isMuted>
-        {t("VersionCompare:versionCompare.noPreviousVersionAvailable")}
-      </Text>
-    );
-  }
 
   return (
       <List className="_cer_v1_named-version-list">

--- a/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
+++ b/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
@@ -179,24 +179,41 @@ export class ChangedElementsWidget extends Component<ChangedElementsWidgetProps,
     manager.versionCompareStarted.addListener(this._onComparisonStarted);
     manager.loadingProgressEvent.addListener(this._onProgressEvent);
     manager.versionCompareStopped.addListener(this._onComparisonStopped);
-
-    this.state = {
-      manager,
-      loading: manager.isComparing,
-      loaded: manager.isComparing,
-      menuOpened: false,
-      elements: manager.changedElementsManager.entryCache.getAll(),
-      currentIModel: manager.currentIModel,
-      targetIModel: manager.targetIModel,
-      message: IModelApp.localization.getLocalizedString("VersionCompare:versionCompare.comparisonNotActive"),
-      description: this.props.useV2Widget
-        ? IModelApp.localization.getLocalizedString("VersionCompare:versionCompare.versionCompareGettingStartedV2")
-        : IModelApp.localization.getLocalizedString("VersionCompare:versionCompare.comparisonGetStarted"),
-      versionSelectDialogVisible: false,
-      informationDialogVisible: false,
-      reportDialogVisible: false,
-      reportProperties: undefined,
-    };
+    if (!this.props.manager?.isComparing) {
+      this.state = {
+        manager,
+        loading: manager.isComparing,
+        loaded: manager.isComparing,
+        menuOpened: false,
+        elements: manager.changedElementsManager.entryCache.getAll(),
+        currentIModel: manager.currentIModel,
+        targetIModel: manager.targetIModel,
+        message: IModelApp.localization.getLocalizedString("VersionCompare:versionCompare.comparisonNotActive"),
+        description: this.props.useV2Widget
+          ? IModelApp.localization.getLocalizedString("VersionCompare:versionCompare.versionCompareGettingStartedV2")
+          : IModelApp.localization.getLocalizedString("VersionCompare:versionCompare.comparisonGetStarted"),
+        versionSelectDialogVisible: false,
+        informationDialogVisible: false,
+        reportDialogVisible: false,
+        reportProperties: undefined,
+      };
+    } else {
+      this.state = {
+        manager,
+        loading: true,
+        loaded: false,
+        menuOpened: false,
+        elements: manager.changedElementsManager.entryCache.getAll(),
+        currentIModel: manager.currentIModel,
+        targetIModel: manager.targetIModel,
+              message: IModelApp.localization.getLocalizedString("VersionCompare:versionCompare.loadingComparison"),
+        description: "",
+        versionSelectDialogVisible: false,
+        informationDialogVisible: false,
+        reportDialogVisible: false,
+        reportProperties: undefined,
+      };
+    }
   }
 
   public override componentWillUnmount(): void {


### PR DESCRIPTION
---
"@itwin/changed-elements-react": patch
---

-Fixes NamedVersionSelectorWidget showing loading and spinning forever when no named version present.

-Fixes default dialog being shown for NamedVersionSelectorWidget when a comparison is started. Now, we show the proper loading state with a spinner instead of "no comparison loaded."