### PR TITLE
Cgerman/UI styling and header updates

### DIFF
--- a/.changeset/unlucky-waves-exercise.md
+++ b/.changeset/unlucky-waves-exercise.md
@@ -1,0 +1,7 @@
+---
+"@itwin/changed-elements-react": patch
+---
+
+- Updates the new experimental widget's font weight and font size.
+- Updates the current and target comparison header info to now be shown on the comparison tree widget.
+- Fixes the filter box to fit the content, getting rid of the horizontal scroll bar.

--- a/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.css
+++ b/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.css
@@ -18,25 +18,14 @@
     }
 
     ._cer_v1_version-selector-header {
-      min-height: calc(3 * var(--iui-size-m));
-      display: grid;
-      grid: 1fr / minmax(min-content, 1fr) max-content minmax(max-content, 1fr);
-      gap: var(--iui-size-xs);
-      place-content: space-between;
+      min-height: calc(var(--iui-size-m));
+      display: flex;
+      justify-content: space-between;
       align-items: center;
-
-      > :first-child {
-        justify-self: start;
-      }
-
-      > :last-child {
-        justify-self: end;
-      }
     }
-
     ._cer_v1_feedback_btn_container {
       margin-top: auto;
-      text-align: center
+      text-align: center;
     }
 
     ._cer_v1_active-versions-box {

--- a/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
+++ b/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
@@ -60,6 +60,7 @@ export function NamedVersionSelectorWidget(props: NamedVersionSelectorWidgetProp
   const { iModel, emptyState, manageVersions , feedbackUrl } = props;
 
   const [isComparing, setIsComparing] = useState(manager.isComparing);
+  const [isComparisonStarted,setIsComparisonStarted] = useState(false);
 
   useEffect(
     () => {
@@ -69,6 +70,10 @@ export function NamedVersionSelectorWidget(props: NamedVersionSelectorWidgetProp
         }),
         manager.versionCompareStopped.addListener(() => {
           setIsComparing(false);
+          setIsComparisonStarted(false);
+        }),
+        manager.versionCompareStarted.addListener(() => {
+          setIsComparisonStarted(true);
         }),
       ];
       return () => cleanup.forEach((cb) => cb());
@@ -96,7 +101,7 @@ export function NamedVersionSelectorWidget(props: NamedVersionSelectorWidgetProp
         <NavigationButton backward onClick={() => manager.stopComparison()}>
           {t("VersionCompare:versionCompare.versionsList")}
         </NavigationButton>
-        <TextEx variant="subheading" weight="bold">
+        <TextEx variant="leading" weight="bold">
           {t("VersionCompare:versionCompare.versionPickerTitle")}
         </TextEx>
         <div>
@@ -115,6 +120,8 @@ export function NamedVersionSelectorWidget(props: NamedVersionSelectorWidgetProp
       <namedVersionSelectorContext.Consumer>
         {(value) => (
           <namedVersionSelectorContext.Provider value={{ ...value, contextExists: true }}>
+            {props.manager?.currentVersion && isComparisonStarted &&
+              <ActiveVersionsBox current={props.manager?.currentVersion} selected={props.manager?.targetVersion}></ActiveVersionsBox>}
             <ChangedElementsWidget
               ref={widgetRef}
               iModelConnection={iModel}
@@ -187,8 +194,7 @@ function NamedVersionSelector(props: NamedVersionSelectorProps): ReactElement {
   return (
     <Widget>
       <Widget.Header>
-        <div />
-        <TextEx variant="subheading" weight="bold">
+        <TextEx variant="leading" weight="bold">
           {t("VersionCompare:versionCompare.versionPickerTitle")}
         </TextEx>
         {currentNamedVersion && <ChangedElementsHeaderButtons onlyInfo />}
@@ -317,7 +323,7 @@ function NamedVersionInfo(props: NamedVersionInfoProps): ReactElement {
       <TextEx variant="leading" weight="bold" overflow="ellipsis">
         {props.namedVersion.displayName}
       </TextEx>
-      <TextEx overflow="ellipsis">{props.namedVersion.description ?? ""}</TextEx>
+      <TextEx variant="small" overflow="ellipsis">{props.namedVersion.description ?? ""}</TextEx>
     </div>
   );
 }
@@ -448,7 +454,7 @@ function NamedVersionSelectorLoaded(props: NamedVersionSelectorLoadedProps): Rea
   return (
       <List className="_cer_v1_named-version-list">
         <Sticky className="_cer_v1_named-version-list-header">
-          <TextEx weight="semibold">
+          <TextEx variant="small">
             {t("VersionCompare:versionCompare.previousVersions")}
           </TextEx>
           {manageVersions}
@@ -488,12 +494,14 @@ const NamedVersionListEntry = forwardRef<HTMLDivElement, NamedVersionEntryProps>
         stateInfo = {
           status: (
             <Flex>
-              <IconEx className="_cer_v1_not-processed" size="xl" fill="currentColor">
+              <IconEx className="_cer_v1_not-processed" size="m" fill="currentColor">
                 <svg viewBox="0 0 16 16">
                   <circle cx="8" cy="8" r="8" />
                 </svg>
               </IconEx>
-              {t("VersionCompare:versionCompare.notProcessed")}
+              <TextEx variant="body">
+                {t("VersionCompare:versionCompare.notProcessed")}
+              </TextEx>
             </Flex>
           ),
           action: (
@@ -520,10 +528,12 @@ const NamedVersionListEntry = forwardRef<HTMLDivElement, NamedVersionEntryProps>
         stateInfo = {
           status: (
             <Flex>
-              <IconEx size="xl" fill="positive">
+              <IconEx size="m" fill="positive">
                 <SvgStatusSuccess />
               </IconEx>
-              {t("VersionCompare:versionCompare.available")}
+              <TextEx variant="body">
+                {t("VersionCompare:versionCompare.available")}
+              </TextEx>
             </Flex>
           ),
           action: (
@@ -539,10 +549,12 @@ const NamedVersionListEntry = forwardRef<HTMLDivElement, NamedVersionEntryProps>
         stateInfo = {
           status: (
             <Flex>
-              <IconEx size="xl" fill="negative" >
+              <IconEx size="m" fill="negative" >
                 <SvgStatusError />
               </IconEx>
-              {t("VersionCompare:versionCompare.error")}
+              <TextEx variant="body">
+                {t("VersionCompare:versionCompare.error")}
+              </TextEx>
             </Flex>
           ),
           action: (
@@ -567,7 +579,7 @@ const NamedVersionListEntry = forwardRef<HTMLDivElement, NamedVersionEntryProps>
             <TextEx variant="leading" weight="bold" overflow="ellipsis">
               {namedVersion.displayName}
             </TextEx>
-            <TextEx overflow="ellipsis">{namedVersion.description ?? ""}</TextEx>
+            <TextEx variant="small" overflow="ellipsis">{namedVersion.description ?? ""}</TextEx>
           </div>
         </div>
         {stateInfo.status}
@@ -647,10 +659,10 @@ function NavigationButton(props: ActionButtonProps): ReactElement {
       onClick={props.onClick}
     >
       <Flex gap="var(--iui-size-xs)">
-        <IconEx size="l" fill="currentColor">
+        <IconEx size="m" fill="currentColor">
           {props.backward ? <SvgChevronLeft /> : <SvgChevronRight />}
         </IconEx>
-        <TextEx weight="semibold">{props.children}</TextEx>
+        <TextEx >{props.children}</TextEx>
       </Flex>
     </Button>
   );

--- a/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
+++ b/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
@@ -101,7 +101,7 @@ export function NamedVersionSelectorWidget(props: NamedVersionSelectorWidgetProp
         <NavigationButton backward onClick={() => manager.stopComparison()}>
           {t("VersionCompare:versionCompare.versionsList")}
         </NavigationButton>
-        <TextEx variant="leading" weight="semibold">
+        <TextEx variant="body" weight="semibold">
           {t("VersionCompare:versionCompare.versionPickerTitle")}
         </TextEx>
         <div>
@@ -194,7 +194,7 @@ function NamedVersionSelector(props: NamedVersionSelectorProps): ReactElement {
   return (
     <Widget>
       <Widget.Header>
-        <TextEx variant="leading" weight="semibold">
+        <TextEx variant="body" weight="semibold">
           {t("VersionCompare:versionCompare.versionPickerTitle")}
         </TextEx>
         {currentNamedVersion && <ChangedElementsHeaderButtons onlyInfo />}
@@ -320,7 +320,7 @@ function NamedVersionInfo(props: NamedVersionInfoProps): ReactElement {
         <TextEx variant="small" weight="light" oblique>{props.annotation}</TextEx>
         <TextEx variant="small" weight="light" oblique>{dateString}</TextEx>
       </Flex>
-      <TextEx variant="leading" weight="bold" overflow="ellipsis">
+      <TextEx variant="body" weight="semibold" overflow="ellipsis">
         {props.namedVersion.displayName}
       </TextEx>
       <TextEx variant="small" overflow="ellipsis">{props.namedVersion.description ?? ""}</TextEx>
@@ -331,9 +331,9 @@ function NamedVersionInfo(props: NamedVersionInfoProps): ReactElement {
 function PlaceholderNamedVersionInfo(): ReactElement {
   return (
     <div className="_cer_v1_placeholder-select-version">
-      <Text isMuted>
+      <TextEx variant="body" weight="normal" isMuted>
         {t("VersionCompare:versionCompare.selectVersionToCompare")}
-      </Text>
+      </TextEx>
     </div>
   );
 }
@@ -574,9 +574,9 @@ const NamedVersionListEntry = forwardRef<HTMLDivElement, NamedVersionEntryProps>
     return (
       <ListItem ref={ref} className="_cer_v1_named-version-entry">
         <div>
-          <TextEx variant="small" overflow="nowrap" oblique>{dateString}</TextEx>
-          <div style={{ display: "grid" }}>
-            <TextEx variant="leading" weight="semibold" overflow="ellipsis">
+          <div style={{ display: "grid", gap: "1px" }}>
+            <TextEx variant="small" overflow="nowrap" oblique>{dateString}</TextEx>
+            <TextEx variant="body" weight="semibold" overflow="ellipsis">
               {namedVersion.displayName}
             </TextEx>
             <TextEx variant="small" overflow="ellipsis">{namedVersion.description ?? ""}</TextEx>
@@ -662,7 +662,7 @@ function NavigationButton(props: ActionButtonProps): ReactElement {
         <IconEx size="m" fill="currentColor">
           {props.backward ? <SvgChevronLeft /> : <SvgChevronRight />}
         </IconEx>
-        <TextEx weight="normal" >{props.children}</TextEx>
+        <TextEx variant="small" weight="normal" >{props.children}</TextEx>
       </Flex>
     </Button>
   );

--- a/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
+++ b/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
@@ -101,7 +101,7 @@ export function NamedVersionSelectorWidget(props: NamedVersionSelectorWidgetProp
         <NavigationButton backward onClick={() => manager.stopComparison()}>
           {t("VersionCompare:versionCompare.versionsList")}
         </NavigationButton>
-        <TextEx variant="leading" weight="bold">
+        <TextEx variant="leading" weight="semibold">
           {t("VersionCompare:versionCompare.versionPickerTitle")}
         </TextEx>
         <div>
@@ -194,7 +194,7 @@ function NamedVersionSelector(props: NamedVersionSelectorProps): ReactElement {
   return (
     <Widget>
       <Widget.Header>
-        <TextEx variant="leading" weight="bold">
+        <TextEx variant="leading" weight="semibold">
           {t("VersionCompare:versionCompare.versionPickerTitle")}
         </TextEx>
         {currentNamedVersion && <ChangedElementsHeaderButtons onlyInfo />}
@@ -317,8 +317,8 @@ function NamedVersionInfo(props: NamedVersionInfoProps): ReactElement {
   return (
     <div>
       <Flex gap="var(--iui-size-xs)">
-        <TextEx variant="small" weight="semibold" oblique>{props.annotation}</TextEx>
-        <TextEx variant="small" weight="normal" oblique>{dateString}</TextEx>
+        <TextEx variant="small" weight="light" oblique>{props.annotation}</TextEx>
+        <TextEx variant="small" weight="light" oblique>{dateString}</TextEx>
       </Flex>
       <TextEx variant="leading" weight="bold" overflow="ellipsis">
         {props.namedVersion.displayName}
@@ -499,7 +499,7 @@ const NamedVersionListEntry = forwardRef<HTMLDivElement, NamedVersionEntryProps>
                   <circle cx="8" cy="8" r="8" />
                 </svg>
               </IconEx>
-              <TextEx variant="body">
+              <TextEx weight="normal" variant="body">
                 {t("VersionCompare:versionCompare.notProcessed")}
               </TextEx>
             </Flex>
@@ -531,7 +531,7 @@ const NamedVersionListEntry = forwardRef<HTMLDivElement, NamedVersionEntryProps>
               <IconEx size="m" fill="positive">
                 <SvgStatusSuccess />
               </IconEx>
-              <TextEx variant="body">
+              <TextEx weight="normal" variant="body">
                 {t("VersionCompare:versionCompare.available")}
               </TextEx>
             </Flex>
@@ -552,7 +552,7 @@ const NamedVersionListEntry = forwardRef<HTMLDivElement, NamedVersionEntryProps>
               <IconEx size="m" fill="negative" >
                 <SvgStatusError />
               </IconEx>
-              <TextEx variant="body">
+              <TextEx weight="normal" variant="body">
                 {t("VersionCompare:versionCompare.error")}
               </TextEx>
             </Flex>
@@ -576,7 +576,7 @@ const NamedVersionListEntry = forwardRef<HTMLDivElement, NamedVersionEntryProps>
         <div>
           <TextEx variant="small" overflow="nowrap" oblique>{dateString}</TextEx>
           <div style={{ display: "grid" }}>
-            <TextEx variant="leading" weight="bold" overflow="ellipsis">
+            <TextEx variant="leading" weight="semibold" overflow="ellipsis">
               {namedVersion.displayName}
             </TextEx>
             <TextEx variant="small" overflow="ellipsis">{namedVersion.description ?? ""}</TextEx>
@@ -662,7 +662,7 @@ function NavigationButton(props: ActionButtonProps): ReactElement {
         <IconEx size="m" fill="currentColor">
           {props.backward ? <SvgChevronLeft /> : <SvgChevronRight />}
         </IconEx>
-        <TextEx >{props.children}</TextEx>
+        <TextEx weight="normal" >{props.children}</TextEx>
       </Flex>
     </Button>
   );

--- a/packages/changed-elements-react/src/NamedVersionSelector/TextEx.css
+++ b/packages/changed-elements-react/src/NamedVersionSelector/TextEx.css
@@ -23,6 +23,14 @@
       font-weight: 700;
     }
 
+    &[data-variant="small"]{
+      font-size: 10px;
+    }
+
+    &[data-variant="body"]{
+      font-size: 12px;
+    }
+
     &[data-overflow="wrap"] {
       white-space: normal;
     }

--- a/packages/changed-elements-react/src/NamedVersionSelector/TextEx.css
+++ b/packages/changed-elements-react/src/NamedVersionSelector/TextEx.css
@@ -8,19 +8,19 @@
 @layer changed-elements-react.v1 {
   ._cer_v1_text {
     &[data-weight="light"] {
-      font-weight: var(--iui-font-weight-light);
+      font-weight: 200;
     }
 
     &[data-weight="normal"] {
-      font-weight: var(--iui-font-weight-normal);
+      font-weight: 400;
     }
 
     &[data-weight="semibold"] {
-      font-weight: var(--iui-font-weight-semibold);
+      font-weight: 600;
     }
 
     &[data-weight="bold"] {
-      font-weight: var(--iui-font-weight-bold);
+      font-weight: 700;
     }
 
     &[data-overflow="wrap"] {

--- a/packages/changed-elements-react/src/NamedVersionSelector/TextEx.tsx
+++ b/packages/changed-elements-react/src/NamedVersionSelector/TextEx.tsx
@@ -46,11 +46,13 @@ export function TextEx(props: TextExProps): ReturnType<typeof Text> {
     overflow,
     color,
     children,
+    variant,
     ...rest
   } = props;
   return (
     <Text
       {...rest}
+      data-variant={variant}
       as={oblique ? "i" : "div"}
       className={clsx("_cer_v1_text", className)}
       data-weight={weight}

--- a/packages/changed-elements-react/src/widgets/EnhancedElementsInspector.tsx
+++ b/packages/changed-elements-react/src/widgets/EnhancedElementsInspector.tsx
@@ -431,7 +431,7 @@ function ChangeTypeFilterHeader(props: FilterHeaderProps): ReactElement {
           <SvgVisibilityHalf />
         </IconButton>
         <div className="filter-header-separator" />
-        <DropdownButton size="small" menuItems={legendButtonItems}>
+        <DropdownButton style={{ minWidth:"fit-content" }} menuItems={legendButtonItems}>
           {IModelApp.localization.getLocalizedString("VersionCompare:versionCompare.filter")}
         </DropdownButton>
       </ExpandableSearchBar>

--- a/packages/changed-elements-react/src/widgets/EnhancedElementsInspector.tsx
+++ b/packages/changed-elements-react/src/widgets/EnhancedElementsInspector.tsx
@@ -29,6 +29,7 @@ import { changedElementsWidgetAttachToViewportEvent } from "./ChangedElementsWid
 import { ElementsList } from "./ElementsList.js";
 
 import "./ChangedElementsInspector.scss";
+import { TextEx } from "../NamedVersionSelector/TextEx.js";
 
 export interface ChangedElementsInspectorProps {
   manager: VersionCompareManager;
@@ -431,8 +432,10 @@ function ChangeTypeFilterHeader(props: FilterHeaderProps): ReactElement {
           <SvgVisibilityHalf />
         </IconButton>
         <div className="filter-header-separator" />
-        <DropdownButton style={{ minWidth:"fit-content" }} menuItems={legendButtonItems}>
-          {IModelApp.localization.getLocalizedString("VersionCompare:versionCompare.filter")}
+        <DropdownButton style={{ minWidth: "fit-content" }} menuItems={legendButtonItems}>
+          <TextEx variant="body" weight="normal">
+            {IModelApp.localization.getLocalizedString("VersionCompare:versionCompare.filter")}
+          </TextEx>
         </DropdownButton>
       </ExpandableSearchBar>
     </div>

--- a/packages/changed-elements-react/src/widgets/InformationButton.tsx
+++ b/packages/changed-elements-react/src/widgets/InformationButton.tsx
@@ -2,7 +2,7 @@
 * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
-import { SvgInfo } from "@itwin/itwinui-icons-react";
+import { SvgInfoCircularHollow } from "@itwin/itwinui-icons-react";
 import { DropdownMenu, IconButton, MenuExtraContent } from "@itwin/itwinui-react";
 import type { ReactNode } from "react";
 
@@ -28,11 +28,10 @@ function InfoButton(props: Props) {
     >
       <IconButton
         data-testid={props["data-testid"]}
-        size="small"
         styleType="borderless"
         aria-label="Information"
       >
-        <SvgInfo />
+        <SvgInfoCircularHollow />
       </IconButton>
     </DropdownMenu>
   );

--- a/packages/test-app-frontend/index.html
+++ b/packages/test-app-frontend/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <link rel="preload" as="font" href="/NotoSans.ttf" crossorigin />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Changed Elements Test App</title>
   </head>

--- a/packages/test-app-frontend/src/App/App.css
+++ b/packages/test-app-frontend/src/App/App.css
@@ -3,12 +3,6 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 
-@font-face {
-  font-family: "Noto Sans";
-  font-style: normal;
-  font-weight: 1 1000;
-  src: local("Noto Sans"), url("/NotoSans.ttf") format("opentype");
-}
 
 .signin-prompt {
   height: 100%;

--- a/packages/test-app-frontend/src/App/App.css
+++ b/packages/test-app-frontend/src/App/App.css
@@ -35,6 +35,8 @@
   margin-left: auto;
   color: var(--iui-color-text-accent);
   padding-left: var(--iui-size-2xs);
-  text-decoration: underline;
   cursor: pointer;
+  font-size: small;
+  font-weight: normal;
+  text-decoration: none;
 }

--- a/packages/test-app-frontend/src/App/App.tsx
+++ b/packages/test-app-frontend/src/App/App.tsx
@@ -31,7 +31,7 @@ export function App(): ReactElement {
 
   return (
     <appContext.Provider value={appContextValue}>
-      <ThemeProvider theme={appContextValue.theme}>
+      <ThemeProvider includeCss={false} theme={appContextValue.theme}>
       <AuthorizationProvider
         authority={applyAuthUrlPrefix("https://ims.bentley.com")}
         clientId={clientId === "spa-xxxxxxxxxxxxxxxxxxxxxxxxx" ? undefined : clientId}

--- a/packages/test-app-frontend/vite.config.ts
+++ b/packages/test-app-frontend/vite.config.ts
@@ -41,14 +41,3 @@ export default defineConfig(() => ({
     port: Number.parseInt(process.env.VITE_FRONTEND_PORT ?? "", 10),
   },
 }));
-
-function stringReplacePlugin(): Plugin {
-  return {
-    name: stringReplacePlugin.name,
-    enforce: "pre",
-    transform: (code: string) => {
-      // iTwin.js by default injects a font that is incorrect and lacks some required font weights
-      return code.replace("document.head.prepend(openSans);", "// document.head.prepend(openSans);");
-    },
-  };
-}

--- a/packages/test-app-frontend/vite.config.ts
+++ b/packages/test-app-frontend/vite.config.ts
@@ -5,7 +5,7 @@
 import react from "@vitejs/plugin-react-swc";
 import { config } from "dotenv-flow";
 import path from "path";
-import { defineConfig, Plugin } from "vite";
+import { defineConfig } from "vite";
 import { viteStaticCopy } from "vite-plugin-static-copy";
 import tsconfigPaths from "vite-tsconfig-paths";
 

--- a/packages/test-app-frontend/vite.config.ts
+++ b/packages/test-app-frontend/vite.config.ts
@@ -15,7 +15,6 @@ config();
 export default defineConfig(() => ({
   plugins: [
     tsconfigPaths(),
-    stringReplacePlugin(),
     react(),
     viteStaticCopy({
       targets: [


### PR DESCRIPTION
Updates to experimental UI. Adjusting font sizes and font weights. Adding a new comparison header when comparison begins and fixing the UI bug for the filter.

Before:
![image](https://github.com/user-attachments/assets/d3d98c5a-e910-4bf0-a8b5-96162b851149)
![image](https://github.com/user-attachments/assets/f1517d84-b776-48dc-a7d9-dddaa0ceb0fd)



After:
![image](https://github.com/user-attachments/assets/1503ebc3-3ccb-4cad-bc45-ef53ddcc44d2)
![image](https://github.com/user-attachments/assets/c9ea6605-3d66-4502-84f5-19d0894361dd)
