### PR TITLE
UI updates for font weight font size font style, coloring and bug fixes

### DIFF
--- a/.changeset/friendly-cats-occur.md
+++ b/.changeset/friendly-cats-occur.md
@@ -1,0 +1,13 @@
+---
+"@itwin/changed-elements-react": patch
+---
+
+UI tweaks for:
+
+- Font size, weight, and style
+- Property comparison table coloring changes per row
+- Updated colors for elements in tree (squares)
+
+Fixes:
+
+- Forever loading in the elements tree when backing out of property comparison (experimental widget only bug)

--- a/packages/changed-elements-react/public/locales/en/VersionCompare.json
+++ b/packages/changed-elements-react/public/locales/en/VersionCompare.json
@@ -112,7 +112,7 @@
     "noPastNamedVersions": "There are no past named versions to compare against.",
     "noPreviousVersionAvailable": "No previous version available",
     "previousVersion": "Previous version",
-    "previousVersions": "Previous Versions",
+    "previousVersions": "Previous versions",
     "processResults": "Process Results",
     "retry": "Retry",
     "selectVersionToCompare": "Select a version to compare",
@@ -139,7 +139,7 @@
     "noChangedProperties": "Element has no changed properties",
     "currentChangeset": "Current Changeset",
     "latestChangeset": "Latest Changeset",
-    "versionsList": "Versions List",
+    "versionsList": "Versions list",
     "viewResults": "View Results"
   },
   "typeOfChange": {

--- a/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
+++ b/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
@@ -101,7 +101,7 @@ export function NamedVersionSelectorWidget(props: NamedVersionSelectorWidgetProp
         <NavigationButton backward onClick={() => manager.stopComparison()}>
           {t("VersionCompare:versionCompare.versionsList")}
         </NavigationButton>
-        <TextEx variant="body" weight="semibold">
+        <TextEx variant="title">
           {t("VersionCompare:versionCompare.versionPickerTitle")}
         </TextEx>
         <div>
@@ -194,7 +194,7 @@ function NamedVersionSelector(props: NamedVersionSelectorProps): ReactElement {
   return (
     <Widget>
       <Widget.Header>
-        <TextEx variant="body" weight="semibold">
+        <TextEx variant="title">
           {t("VersionCompare:versionCompare.versionPickerTitle")}
         </TextEx>
         {currentNamedVersion && <ChangedElementsHeaderButtons onlyInfo />}
@@ -531,7 +531,7 @@ const NamedVersionListEntry = forwardRef<HTMLDivElement, NamedVersionEntryProps>
               <IconEx size="m" fill="positive">
                 <SvgStatusSuccess />
               </IconEx>
-              <TextEx weight="normal" variant="body">
+              <TextEx variant="body">
                 {t("VersionCompare:versionCompare.available")}
               </TextEx>
             </Flex>
@@ -662,7 +662,7 @@ function NavigationButton(props: ActionButtonProps): ReactElement {
         <IconEx size="m" fill="currentColor">
           {props.backward ? <SvgChevronLeft /> : <SvgChevronRight />}
         </IconEx>
-        <TextEx variant="small" weight="normal" >{props.children}</TextEx>
+        <TextEx variant="body" weight="normal" >{props.children}</TextEx>
       </Flex>
     </Button>
   );

--- a/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
+++ b/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
@@ -317,7 +317,7 @@ function NamedVersionInfo(props: NamedVersionInfoProps): ReactElement {
   return (
     <div>
       <Flex gap="var(--iui-size-xs)">
-        <TextEx variant="small" weight="light" oblique>{props.annotation}</TextEx>
+        <TextEx variant="small" weight="semibold" oblique>{props.annotation}</TextEx>
         <TextEx variant="small" weight="light" oblique>{dateString}</TextEx>
       </Flex>
       <TextEx variant="body" weight="semibold" overflow="ellipsis">

--- a/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
+++ b/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
@@ -60,7 +60,7 @@ export function NamedVersionSelectorWidget(props: NamedVersionSelectorWidgetProp
   const { iModel, emptyState, manageVersions , feedbackUrl } = props;
 
   const [isComparing, setIsComparing] = useState(manager.isComparing);
-  const [isComparisonStarted,setIsComparisonStarted] = useState(false);
+  const [isComparisonStarted, setIsComparisonStarted] = useState(manager.isComparisonReady);
 
   useEffect(
     () => {

--- a/packages/changed-elements-react/src/NamedVersionSelector/TextEx.css
+++ b/packages/changed-elements-react/src/NamedVersionSelector/TextEx.css
@@ -8,27 +8,31 @@
 @layer changed-elements-react.v1 {
   ._cer_v1_text {
     &[data-weight="light"] {
-      font-weight: 200;
+      font-weight: var(--iui-font-weight-light);
     }
 
     &[data-weight="normal"] {
-      font-weight: 400;
+      font-weight: var(--iui-font-weight-normal);
     }
 
     &[data-weight="semibold"] {
-      font-weight: 600;
+      font-weight: var(--iui-font-weight-semibold);
     }
 
     &[data-weight="bold"] {
-      font-weight: 700;
+      font-weight: var(--iui-font-weight-bold);
     }
 
     &[data-variant="small"]{
-      font-size: 10px;
+      font-size: var(--iui-font-size-0);
     }
 
     &[data-variant="body"]{
-      font-size: 12px;
+      font-size: var(--iui-font-size-1);
+    }
+
+    &[data-variant="title"]{
+      font-size: var(--iui-font-size-2);
     }
 
     &[data-overflow="wrap"] {

--- a/packages/changed-elements-react/src/api/VersionCompareManager.ts
+++ b/packages/changed-elements-react/src/api/VersionCompareManager.ts
@@ -132,7 +132,7 @@ export class VersionCompareManager {
 
   private _currentIModel: IModelConnection | undefined;
   private _targetIModel: IModelConnection | undefined;
-  private _startedComparing: boolean = false;
+  private _isComparisonStarted: boolean = false;
 
   /** Get current IModelConnection being compared against. */
   public get currentIModel(): IModelConnection | undefined {
@@ -143,10 +143,14 @@ export class VersionCompareManager {
   public get targetIModel(): IModelConnection | undefined {
     return this._targetIModel;
   }
+  /** Returns true if version compare manager is ready to show loaded comparison.*/
+  public get isComparisonReady(): boolean {
+    return this._isComparisonStarted;
+  }
 
-  /** Returns true if version compare manager is currently engaged in comparison. */
+  /** Returns true if version compare manager is currently engaged in comparison.*/
   public get isComparing(): boolean {
-    return this._targetIModel !== undefined || this._startedComparing === true;
+    return this._targetIModel !== undefined;
   }
 
   /**
@@ -252,7 +256,6 @@ export class VersionCompareManager {
     changesetChunks?: ChangesetChunk[],
   ): Promise<boolean> {
     this._currentIModel = currentIModel;
-    this._startedComparing = true;
     let success = true;
     try {
       if (!targetVersion.changesetId) {
@@ -315,7 +318,6 @@ export class VersionCompareManager {
         this.filterSpatial,
         this.loadingProgressEvent,
       );
-
       const changedElementEntries = this.changedElementsManager.entryCache.getAll();
 
       // We have parent Ids available if any entries contain undefined parent data
@@ -344,6 +346,7 @@ export class VersionCompareManager {
       // Raise event
       this.versionCompareStarted.raiseEvent(this._currentIModel, this._targetIModel, changedElementEntries);
       VersionCompareUtils.outputVerbose(VersionCompareVerboseMessages.versionCompareManagerStartedComparison);
+      this._isComparisonStarted = true;
       VersionCompare.manager?.featureTracking?.trackVersionSelectorUsage();
     } catch (ex) {
       // Let user know comparison failed - TODO: Give better errors
@@ -365,7 +368,7 @@ export class VersionCompareManager {
       this.versionCompareStartFailed.raiseEvent();
       this._currentIModel = undefined;
       this._targetIModel = undefined;
-      this._startedComparing = false;
+      this._isComparisonStarted = false;
       success = false;
       VersionCompareUtils.outputVerbose(VersionCompareVerboseMessages.versionCompareManagerErrorStarting);
     }
@@ -387,7 +390,6 @@ export class VersionCompareManager {
     changedElements: ChangedElements[],
   ): Promise<boolean> {
     this._currentIModel = currentIModel;
-    this._startedComparing = true;
     let success = true;
     try {
       if (!targetVersion.changesetId) {
@@ -475,6 +477,7 @@ export class VersionCompareManager {
       // Raise event
       this.versionCompareStarted.raiseEvent(this._currentIModel, this._targetIModel, changedElementEntries);
       VersionCompareUtils.outputVerbose(VersionCompareVerboseMessages.versionCompareManagerStartedComparison);
+      this._isComparisonStarted = true;
       VersionCompare.manager?.featureTracking?.trackVersionSelectorV2Usage();
     } catch (ex) {
       // Let user know comparison failed - TODO: Give better errors
@@ -497,7 +500,7 @@ export class VersionCompareManager {
       } finally {
         this._currentIModel = undefined;
         this._targetIModel = undefined;
-        this._startedComparing = false;
+        this._isComparisonStarted = false;
         success = false;
         VersionCompareUtils.outputVerbose(VersionCompareVerboseMessages.versionCompareManagerErrorStarting);
 
@@ -531,7 +534,7 @@ export class VersionCompareManager {
       if (this._targetIModel) {
         await this._targetIModel.close();
         this._targetIModel = undefined;
-        this._startedComparing = false;
+        this._isComparisonStarted = false;
       }
 
       this.changedElementsManager.cleanup();
@@ -539,7 +542,7 @@ export class VersionCompareManager {
       // Reset the select tool to allow external iModels to be located
       await IModelApp.toolAdmin.startDefaultTool();
     } catch (ex) {
-      this._startedComparing = false;
+      this._isComparisonStarted = false;
       // Log anything not a string or we don't handle
       Logger.logError(LOGGER_CATEGORY, "Failed to stop comparison", () => ({ ex }));
     }
@@ -549,7 +552,7 @@ export class VersionCompareManager {
     this.targetVersion = undefined;
     this._currentIModel = undefined;
     this._targetIModel = undefined;
-    this._startedComparing = false;
+    this._isComparisonStarted = false;
 
     // Clean-up visualization handler
     await this._visualizationHandler?.cleanUp();

--- a/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.scss
+++ b/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.scss
@@ -56,20 +56,23 @@
   }
 
   /* Override status positive color */
-._iui3166-table-body ._iui3166-table-row[data-iui-status=positive] ._iui3166-table-cell:first-of-type,
-._iui3166-table-body ._iui3166-table-row[data-iui-status=positive]+._iui3166-table-expanded-content {
-  box-shadow: inset var(--iui-size-2xs) 0 0 0 var(--iui-color-background-positive-hover) !important; /* Your custom color */
-}
+  .added-row {
+    > :first-child {
+      box-shadow: inset .4rem 0 0 0 var(--iui-color-background-positive-hover);
+    }
+  }
 
   /* Override status warning color */
-._iui3166-table-body ._iui3166-table-row[data-iui-status=warning] ._iui3166-table-cell:first-of-type,
-._iui3166-table-body ._iui3166-table-row[data-iui-status=warning]+._iui3166-table-expanded-content {
-  box-shadow: inset var(--iui-size-2xs) 0 0 0 var(--iui-color-background-informational-hover) !important; /* Your custom color */
-}
+  .modified-row {
+    > :first-child {
+      box-shadow: inset .4rem 0 0 0 var(--iui-color-background-informational-hover);
+    }
+  }
 
   /* Override status warning color */
-._iui3166-table-body ._iui3166-table-row[data-iui-status=negative] ._iui3166-table-cell:first-of-type,
-._iui3166-table-body ._iui3166-table-row[data-iui-status=negative]+._iui3166-table-expanded-content {
-  box-shadow: inset var(--iui-size-2xs) 0 0 0 var(--iui-color-background-negative-hover) !important; /* Your custom color */
-}
+  .removed-row {
+    > :first-child {
+      box-shadow: inset .4rem 0 0 0 var(--iui-color-background-negative-hover);
+    }
+  }
 }

--- a/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.scss
+++ b/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.scss
@@ -55,27 +55,21 @@
     }
   }
 
-  .row-added.iui-table-row .iui-table-cell {
-    background: #56aa1c;
-  }
+  /* Override status positive color */
+._iui3166-table-body ._iui3166-table-row[data-iui-status=positive] ._iui3166-table-cell:first-of-type,
+._iui3166-table-body ._iui3166-table-row[data-iui-status=positive]+._iui3166-table-expanded-content {
+  box-shadow: inset var(--iui-size-2xs) 0 0 0 var(--iui-color-background-positive-hover) !important; /* Your custom color */
+}
 
-  .row-added.iui-table-row:hover .iui-table-cell {
-    background: #d4f4bd;
-  }
+  /* Override status warning color */
+._iui3166-table-body ._iui3166-table-row[data-iui-status=warning] ._iui3166-table-cell:first-of-type,
+._iui3166-table-body ._iui3166-table-row[data-iui-status=warning]+._iui3166-table-expanded-content {
+  box-shadow: inset var(--iui-size-2xs) 0 0 0 var(--iui-color-background-informational-hover) !important; /* Your custom color */
+}
 
-  .row-deleted.iui-table-row .iui-table-cell {
-    background: #cc0000;
-  }
-
-  .row-deleted.iui-table-row:hover .iui-table-cell {
-    background: #ffb3b3;
-  }
-
-  .row-modified.iui-table-row .iui-table-cell {
-    background: #008be1;
-  }
-
-  .row-modified.iui-table-row:hover .iui-table-cell {
-    background: #b3e2ff;
-  }
+  /* Override status warning color */
+._iui3166-table-body ._iui3166-table-row[data-iui-status=negative] ._iui3166-table-cell:first-of-type,
+._iui3166-table-body ._iui3166-table-row[data-iui-status=negative]+._iui3166-table-expanded-content {
+  box-shadow: inset var(--iui-size-2xs) 0 0 0 var(--iui-color-background-negative-hover) !important; /* Your custom color */
+}
 }

--- a/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.tsx
+++ b/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.tsx
@@ -169,16 +169,6 @@ function useColumnsDefinition(
           id: "category",
           Header: IModelApp.localization.getLocalizedString("VersionCompare:versionCompare.category"),
           accessor: "category",
-          //  cellRenderer: (props) => {
-          //    return (
-          //      <DefaultCell
-          //        {...props}
-          //        className="row-added"
-          //      >
-          //        blah
-          //      </DefaultCell>
-          //    );
-          //  },
         },
         {
           id: "propertyName",

--- a/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.tsx
+++ b/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.tsx
@@ -5,7 +5,7 @@
 import { PropertyRecord, PropertyValueFormat } from "@itwin/appui-abstract";
 import { Logger } from "@itwin/core-bentley";
 import { IModelApp, type IModelConnection } from "@itwin/core-frontend";
-import { DefaultCell, IconButton, Slider, Table, Text, ToggleSwitch } from "@itwin/itwinui-react";
+import { IconButton, Slider, Table, Text, ToggleSwitch } from "@itwin/itwinui-react";
 import type { KeySet } from "@itwin/presentation-common";
 import { PresentationPropertyDataProvider } from "@itwin/presentation-components";
 import { memo, useEffect, useMemo, useRef, useState, type ReactElement } from "react";

--- a/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.tsx
+++ b/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.tsx
@@ -625,20 +625,19 @@ function SideBySideToggle(props: SideBySideToggleProps): ReactElement {
 }
 
 const getRowProps: (row: Row<ComparisonDataRow>) => React.ComponentPropsWithRef<"div"> & {
-  status?: "positive" | "warning" | "negative";
   isLoading?: boolean;
 } = (row) => {
   const { current, target } = row.values;
   if (current === "" && target !== "") {
-    return { status: "negative" };
+    return { className:"removed-row" };
   }
 
   if (current !== "" && target === "") {
-    return { status: "positive" };
+    return { className: "added-row" };
   }
 
   if (current !== target) {
-    return { status: "warning" };
+    return { className: "modified-row"};
   }
 
   return {};

--- a/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.tsx
+++ b/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.tsx
@@ -5,7 +5,7 @@
 import { PropertyRecord, PropertyValueFormat } from "@itwin/appui-abstract";
 import { Logger } from "@itwin/core-bentley";
 import { IModelApp, type IModelConnection } from "@itwin/core-frontend";
-import { IconButton, Slider, Table, Text, ToggleSwitch } from "@itwin/itwinui-react";
+import { DefaultCell, IconButton, Slider, Table, Text, ToggleSwitch } from "@itwin/itwinui-react";
 import type { KeySet } from "@itwin/presentation-common";
 import { PresentationPropertyDataProvider } from "@itwin/presentation-components";
 import { memo, useEffect, useMemo, useRef, useState, type ReactElement } from "react";
@@ -169,6 +169,16 @@ function useColumnsDefinition(
           id: "category",
           Header: IModelApp.localization.getLocalizedString("VersionCompare:versionCompare.category"),
           accessor: "category",
+          //  cellRenderer: (props) => {
+          //    return (
+          //      <DefaultCell
+          //        {...props}
+          //        className="row-added"
+          //      >
+          //        blah
+          //      </DefaultCell>
+          //    );
+          //  },
         },
         {
           id: "propertyName",
@@ -630,15 +640,15 @@ const getRowProps: (row: Row<ComparisonDataRow>) => React.ComponentPropsWithRef<
 } = (row) => {
   const { current, target } = row.values;
   if (current === "" && target !== "") {
-    return { className: "row-deleted", status: "negative" };
+    return { status: "negative" };
   }
 
   if (current !== "" && target === "") {
-    return { className: "row-added", status: "positive" };
+    return { status: "positive" };
   }
 
   if (current !== target) {
-    return { className: "row-modified", status: "warning" };
+    return { status: "warning" };
   }
 
   return {};

--- a/packages/changed-elements-react/src/widgets/ChangedElementsInspector.scss
+++ b/packages/changed-elements-react/src/widgets/ChangedElementsInspector.scss
@@ -284,15 +284,15 @@
 }
 
 .added {
-  color: RGB(86, 170, 28);
+  color: var(--iui-color-background-positive-hover);
 }
 
 .modified {
-  color: RGB(0, 139, 225);
+  color: var(--iui-color-background-informational-hover);
 }
 
 .deleted {
-  color: RGB(204, 0, 0);
+  color: var(--iui-color-background-negative-hover);
 }
 
 .unchanged {

--- a/packages/changed-elements-react/src/widgets/ChangedElementsInspector.scss
+++ b/packages/changed-elements-react/src/widgets/ChangedElementsInspector.scss
@@ -307,8 +307,8 @@
 
   &-modified {
     @extend .change-square;
-    background-color: RGB(0, 139, 225);
-    border-color: RGB(0, 139, 225);
+    background-color: var(--iui-color-background-informational-hover);
+    border-color: var(--iui-color-background-informational-hover);
   }
 
   &-indirect {
@@ -318,14 +318,14 @@
 
   &-added {
     @extend .change-square;
-    background-color: RGB(86, 170, 28);
-    border-color: RGB(86, 170, 28);
+    background-color: var(--iui-color-background-positive-hover);
+    border-color: var(--iui-color-background-positive-hover);
   }
 
   &-deleted {
     @extend .change-square;
-    background-color: RGB(204, 0, 0);
-    border-color: RGB(204, 0, 0);
+    background-color: var(--iui-color-background-negative-hover);
+    border-color: var(--iui-color-background-negative-hover);
   }
 }
 

--- a/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
+++ b/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
@@ -179,11 +179,11 @@ export class ChangedElementsWidget extends Component<ChangedElementsWidgetProps,
     manager.versionCompareStarted.addListener(this._onComparisonStarted);
     manager.loadingProgressEvent.addListener(this._onProgressEvent);
     manager.versionCompareStopped.addListener(this._onComparisonStopped);
-    if (!this.props.manager?.isComparing) {
+    if (manager.isComparisonReady) {
       this.state = {
         manager,
-        loading: manager.isComparing,
-        loaded: manager.isComparing,
+        loading: !manager.isComparisonReady,
+        loaded: manager.isComparisonReady,
         menuOpened: false,
         elements: manager.changedElementsManager.entryCache.getAll(),
         currentIModel: manager.currentIModel,
@@ -206,7 +206,7 @@ export class ChangedElementsWidget extends Component<ChangedElementsWidgetProps,
         elements: manager.changedElementsManager.entryCache.getAll(),
         currentIModel: manager.currentIModel,
         targetIModel: manager.targetIModel,
-              message: IModelApp.localization.getLocalizedString("VersionCompare:versionCompare.loadingComparison"),
+        message: IModelApp.localization.getLocalizedString("VersionCompare:versionCompare.loadingComparison"),
         description: "",
         versionSelectDialogVisible: false,
         informationDialogVisible: false,


### PR DESCRIPTION
Font size, weight, and style:
![image](https://github.com/user-attachments/assets/a08a9d37-79b7-4dfa-9336-def97219e566)
![image](https://github.com/user-attachments/assets/c4b64e71-1249-4bc0-83e2-75bcda100e64)

Property comparison table coloring changes per row :
![image](https://github.com/user-attachments/assets/a5b34aa6-28ab-4735-a1b2-89a455949df6)
![image](https://github.com/user-attachments/assets/10c39ac7-509f-4cb8-936f-8a8fca3dae5a)

Updated colors for elements in tree (Squares) :
![image](https://github.com/user-attachments/assets/89dc973a-264a-4fc6-9ccd-63f28a1b45eb)
![image](https://github.com/user-attachments/assets/ee1ea739-b790-4a68-820e-dafc66dfce85)

No more forever loading in the elements tree when backing out of property comparison :

![Recording 2025-02-19 at 11 55 24](https://github.com/user-attachments/assets/7919c4c3-a8ae-4585-9909-d699f3ffb9f5)
