### PR TITLE
Fixed css for property-comparison-table-slider

### DIFF
--- a/.changeset/three-stars-bake.md
+++ b/.changeset/three-stars-bake.md
@@ -1,0 +1,5 @@
+---
+"@itwin/changed-elements-react": patch
+---
+
+- Fixed CSS for property comparison table slider

--- a/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.scss
+++ b/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.scss
@@ -33,11 +33,15 @@
       }
     }
 
-    >.imodel-slider {
-        width: 100%;
-        max-width: 600px;
+  > [class*="slider-container"] {
+      width: 100%;
+      justify-content: center;
+      max-width: 800px;
+    [class$="-slider"] {
+        max-width: 100%;
         min-width: 200px;
-      }
+    }
+    }
 
     > .settings {
       grid-area: settings;

--- a/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.scss
+++ b/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.scss
@@ -33,14 +33,14 @@
       }
     }
 
-  > [class*="slider-container"] {
+    > [class*="slider-container"] {
       width: 100%;
       justify-content: center;
       max-width: 800px;
-    [class$="-slider"] {
+      [class$="-slider"] {
         max-width: 100%;
         min-width: 200px;
-    }
+      }
     }
 
     > .settings {
@@ -58,21 +58,22 @@
   /* Override status positive color */
   .added-row {
     > :first-child {
-      box-shadow: inset .4rem 0 0 0 var(--iui-color-background-positive-hover);
+      box-shadow: inset 0.4rem 0 0 0 var(--iui-color-background-positive-hover);
     }
   }
 
   /* Override status warning color */
   .modified-row {
     > :first-child {
-      box-shadow: inset .4rem 0 0 0 var(--iui-color-background-informational-hover);
+      box-shadow: inset 0.4rem 0 0 0
+        var(--iui-color-background-informational-hover);
     }
   }
 
   /* Override status warning color */
   .removed-row {
     > :first-child {
-      box-shadow: inset .4rem 0 0 0 var(--iui-color-background-negative-hover);
+      box-shadow: inset 0.4rem 0 0 0 var(--iui-color-background-negative-hover);
     }
   }
 }

--- a/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.scss
+++ b/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.scss
@@ -33,15 +33,11 @@
       }
     }
 
-    > .iui-slider-component-container {
-      width: 100%;
-      justify-content: center;
-
-      .iui-slider-container {
-        min-width: 200px;
+    >.imodel-slider {
+        width: 100%;
         max-width: 600px;
+        min-width: 200px;
       }
-    }
 
     > .settings {
       grid-area: settings;

--- a/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.tsx
+++ b/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.tsx
@@ -587,6 +587,7 @@ interface OverviewOpacitySliderProps {
 function OverviewOpacitySlider(props: OverviewOpacitySliderProps) {
   return (
     <Slider
+      className="imodel-slider"
       min={0}
       max={100}
       values={[50]}

--- a/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.tsx
+++ b/packages/changed-elements-react/src/contentviews/PropertyComparisonTable.tsx
@@ -587,7 +587,6 @@ interface OverviewOpacitySliderProps {
 function OverviewOpacitySlider(props: OverviewOpacitySliderProps) {
   return (
     <Slider
-      className="imodel-slider"
       min={0}
       max={100}
       values={[50]}


### PR DESCRIPTION
Fixed CSS for property-comparison-table-slider:

Before:
![image](https://github.com/user-attachments/assets/a59d62f3-9b45-4a6a-aa7d-3da7b0c52ad7)

After :
![image](https://github.com/user-attachments/assets/14f98d47-a7a4-4778-8646-c82c2cca96ed)
