### PR TITLE
Info Button Docs Link Sub Component

### DIFF
--- a/.changeset/big-bushes-repeat.md
+++ b/.changeset/big-bushes-repeat.md
@@ -1,0 +1,6 @@
+---
+"@itwin/changed-elements-react": minor
+---
+
+- Added ability to add custom documentation link to information pane.
+  Pass href into top level widget as prop.

--- a/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
+++ b/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
@@ -45,6 +45,7 @@ interface NamedVersionSelectorWidgetProps {
   emptyState?: ReactNode;
   manageVersions?: ReactNode;
   feedbackUrl?: string;
+  documentationHref?: string;
 }
 
 /**
@@ -117,6 +118,7 @@ export function NamedVersionSelectorWidget(props: Readonly<NamedVersionSelectorW
               ? () => void widgetRef.current?.openReportDialog()
               : undefined
           }
+          documentationHref={props.documentationHref}
         />
       </Widget.Header>
       <namedVersionSelectorContext.Consumer>
@@ -202,6 +204,7 @@ interface NamedVersionSelectorProps {
   emptyState?: ReactNode;
   manageVersions?: ReactNode;
   feedbackUrl?: string;
+  documentationHref?: string;
 }
 
 function NamedVersionSelector(props: Readonly<NamedVersionSelectorProps>): ReactElement {
@@ -271,7 +274,7 @@ function NamedVersionSelector(props: Readonly<NamedVersionSelectorProps>): React
         <TextEx variant="title">
           {t("VersionCompare:versionCompare.versionPickerTitle")}
         </TextEx>
-        {currentNamedVersion && <ChangedElementsHeaderButtons onlyInfo />}
+        {currentNamedVersion && <ChangedElementsHeaderButtons documentationHref={props.documentationHref} onlyInfo />}
       </Widget.Header>
       {
         currentNamedVersion &&

--- a/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
+++ b/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
@@ -96,6 +96,7 @@ export function NamedVersionSelectorWidget(props: Readonly<NamedVersionSelectorW
         emptyState={emptyState}
         manageVersions={manageVersions}
         feedbackUrl={feedbackUrl}
+        documentationHref = {props.documentationHref}
       />
     );
   }

--- a/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
+++ b/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
@@ -7,7 +7,7 @@ import {
   IModelApp, NotifyMessageDetails, OutputMessagePriority, type IModelConnection, type ScreenViewport
 } from "@itwin/core-frontend";
 import { SvgAdd, SvgCompare, SvgExport, SvgStop } from "@itwin/itwinui-icons-react";
-import { IconButton, ProgressRadial, Text, useToaster } from "@itwin/itwinui-react";
+import { Divider, IconButton, ProgressRadial, Text, useToaster } from "@itwin/itwinui-react";
 import { Component, type ReactElement, type ReactNode } from "react";
 
 import { namedVersionSelectorContext } from "../NamedVersionSelector/NamedVersionSelectorContext.js";
@@ -35,6 +35,7 @@ import {
 import { JobAndNamedVersions } from "./comparisonJobWidget/models/ComparisonJobModels.js";
 
 import "./ChangedElementsWidget.scss";
+import { Documentation } from "./Documentation.js";
 
 export const changedElementsWidgetAttachToViewportEvent = new BeEvent<(vp: ScreenViewport) => void>();
 
@@ -59,6 +60,12 @@ export interface ChangedElementsWidgetProps {
    * @beta
    */
   useV2Widget?: boolean;
+
+  /**
+ * Optional. If set information button will show documentation link.
+ * @beta
+ */
+  documentationHref?: string;
 
   /**
  * Optional. Only true if the new named version selector is being used.
@@ -398,6 +405,7 @@ export class ChangedElementsWidget extends Component<ChangedElementsWidgetProps,
                         this.state.manager.wantReportGeneration ? this.openReportDialog : undefined
                       }
                       onInspect={this._handleInspect}
+                      documentationHref={this.props.documentationHref}
                     />
                   </WidgetComponent.Header.Actions>
                 </WidgetComponent.Header>
@@ -476,17 +484,18 @@ export class ChangedElementsWidget extends Component<ChangedElementsWidgetProps,
 let reportIsBeingGenerated = false;
 
 interface ChangedElementsHeaderButtonsProps {
-  loaded?: boolean | undefined;
-  useV2Widget?: boolean | undefined;
-  useNewNamedVersionSelector?: boolean | undefined;
-  onlyInfo?: boolean | undefined;
-  onOpenVersionSelector?: (() => void) | undefined;
+  loaded?: boolean;
+  useV2Widget?: boolean
+  useNewNamedVersionSelector?: boolean;
+  onlyInfo?: boolean;
+  onOpenVersionSelector?: (() => void);
   onStopComparison?: (() => void) | undefined;
-  onOpenReportDialog?: (() => void) | undefined;
-  onInspect?: (() => void) | undefined;
+  onOpenReportDialog?: (() => void);
+  onInspect?: (() => void);
+  documentationHref: string;
 }
 
-export function ChangedElementsHeaderButtons(props: ChangedElementsHeaderButtonsProps): ReactElement {
+export function ChangedElementsHeaderButtons(props: Readonly<ChangedElementsHeaderButtonsProps>): ReactElement {
   const t = (key: string) => IModelApp.localization.getLocalizedString(key);
 
   const paragraphs = t("VersionCompare:versionCompare.versionCompareInfoV2").split("\n");
@@ -496,6 +505,12 @@ export function ChangedElementsHeaderButtons(props: ChangedElementsHeaderButtons
         {IModelApp.localization.getLocalizedString("VersionCompare:versionCompare.versionCompare")}
       </Text>
       {paragraphs.map((paragraph, i) => <p key={i}>{paragraph}</p>)}
+      {props.documentationHref && (
+        <>
+        <Divider />
+        <Documentation href={props.documentationHref} />
+      </>
+      )}
     </InfoButton>
   );
 

--- a/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
+++ b/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
@@ -485,7 +485,7 @@ let reportIsBeingGenerated = false;
 
 interface ChangedElementsHeaderButtonsProps {
   loaded?: boolean;
-  useV2Widget?: boolean
+  useV2Widget?: boolean;
   useNewNamedVersionSelector?: boolean;
   onlyInfo?: boolean;
   onOpenVersionSelector?: (() => void);

--- a/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
+++ b/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
@@ -489,7 +489,7 @@ interface ChangedElementsHeaderButtonsProps {
   useNewNamedVersionSelector?: boolean;
   onlyInfo?: boolean;
   onOpenVersionSelector?: (() => void);
-  onStopComparison?: (() => void) | undefined;
+  onStopComparison?: (() => void);
   onOpenReportDialog?: (() => void);
   onInspect?: (() => void);
   documentationHref?: string;

--- a/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
+++ b/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
@@ -492,7 +492,7 @@ interface ChangedElementsHeaderButtonsProps {
   onStopComparison?: (() => void) | undefined;
   onOpenReportDialog?: (() => void);
   onInspect?: (() => void);
-  documentationHref: string;
+  documentationHref?: string;
 }
 
 export function ChangedElementsHeaderButtons(props: Readonly<ChangedElementsHeaderButtonsProps>): ReactElement {

--- a/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
+++ b/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
@@ -506,7 +506,7 @@ export function ChangedElementsHeaderButtons(props: Readonly<ChangedElementsHead
       </Text>
       {paragraphs.map((paragraph, i) => <p key={i}>{paragraph}</p>)}
       {props.documentationHref && (
-        <>
+      <>
         <Divider />
         <Documentation href={props.documentationHref} />
       </>

--- a/packages/changed-elements-react/src/widgets/Documentation.scss
+++ b/packages/changed-elements-react/src/widgets/Documentation.scss
@@ -1,0 +1,27 @@
+/* Container for the entire button content */
+.documentation-button-container {
+  margin-top: 4px;
+  color: var(--iui-color-text-accent);
+  cursor: pointer;
+  font-size: small;
+  font-weight: normal;
+  text-decoration: none;
+}
+
+.documentation-button-container:hover {
+  color: var(--iui-color-background-informational-hover);
+}
+
+/* Content inside the button (icon and text) */
+.documentation-button-content {
+  display: flex; /* Use flexbox layout */
+  flex-direction: row; /* Arrange children in a row */
+  gap: 2px; /* Add spacing between children */
+  align-items: center; /* Align children vertically in the center */
+  color: var(--iui-text-color-informational); /* Set text color to informational */
+}
+
+/* Text inside the button */
+.documentation-button-text {
+  color: var(--iui-color-background-informational); /* Set text color */
+}

--- a/packages/changed-elements-react/src/widgets/Documentation.scss
+++ b/packages/changed-elements-react/src/widgets/Documentation.scss
@@ -1,4 +1,8 @@
-/* Container for the entire button content */
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+
 .documentation-button-container {
   margin-top: 4px;
   color: var(--iui-color-text-accent);
@@ -12,16 +16,14 @@
   color: var(--iui-color-background-informational-hover);
 }
 
-/* Content inside the button (icon and text) */
 .documentation-button-content {
-  display: flex; /* Use flexbox layout */
-  flex-direction: row; /* Arrange children in a row */
-  gap: 2px; /* Add spacing between children */
-  align-items: center; /* Align children vertically in the center */
-  color: var(--iui-text-color-informational); /* Set text color to informational */
+  display: flex;
+  flex-direction: row;
+  gap: 2px;
+  align-items: center;
+  color: var(--iui-text-color-informational);
 }
 
-/* Text inside the button */
 .documentation-button-text {
-  color: var(--iui-color-background-informational); /* Set text color */
+  color: var(--iui-color-background-informational);
 }

--- a/packages/changed-elements-react/src/widgets/Documentation.tsx
+++ b/packages/changed-elements-react/src/widgets/Documentation.tsx
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
+import { SvgDocument, SvgWindowPopout } from "@itwin/itwinui-icons-react";
+import { Flex, Text } from "@itwin/itwinui-react";
+import { IconEx } from "../NamedVersionSelector/IconEx.js";
+import "./Documentation.scss";
+
+interface DocumentationProps {
+  href: string;
+}
+
+/**
+ * A component that renders a documentation button with an icon and text.
+ * Clicking the button opens the provided documentation link in a new tab.
+ *
+ * @param {Readonly<DocumentationProps>} props - The props for the component.
+ * @returns {JSX.Element} The rendered Documentation component.
+ */
+export function Documentation(props: Readonly<DocumentationProps>) {
+  const handleClick = () => { };
+  return (<Flex className="documentation-button-container" as="a" href={props.href} target="_blank" rel="noopener noreferrer" onClick={handleClick}>
+    <div className="documentation-button-content">
+      <IconEx size="m" fill="informational">
+        {<SvgDocument />}
+      </IconEx>
+      <Text className="documentation-button-text">Documentation</Text>
+    </div>
+    <Flex.Spacer />
+    <IconEx size="m" fill="informational">
+      {<SvgWindowPopout />}
+    </IconEx>
+  </Flex>);
+}

--- a/packages/changed-elements-react/src/widgets/Documentation.tsx
+++ b/packages/changed-elements-react/src/widgets/Documentation.tsx
@@ -6,6 +6,7 @@ import { SvgDocument, SvgWindowPopout } from "@itwin/itwinui-icons-react";
 import { Flex, Text } from "@itwin/itwinui-react";
 import { IconEx } from "../NamedVersionSelector/IconEx.js";
 import "./Documentation.scss";
+import { IModelApp } from "@itwin/core-frontend";
 
 interface DocumentationProps {
   href: string;
@@ -19,13 +20,16 @@ interface DocumentationProps {
  * @returns {JSX.Element} The rendered Documentation component.
  */
 export function Documentation(props: Readonly<DocumentationProps>) {
-  const handleClick = () => { };
-  return (<Flex className="documentation-button-container" as="a" href={props.href} target="_blank" rel="noopener noreferrer" onClick={handleClick}>
+  return (<Flex className="documentation-button-container" as="a" href={props.href} target="_blank" rel="noopener noreferrer">
     <div className="documentation-button-content">
       <IconEx size="m" fill="informational">
         {<SvgDocument />}
       </IconEx>
-      <Text className="documentation-button-text">Documentation</Text>
+      <Text className="documentation-button-text">
+        {
+          IModelApp.localization.getLocalizedString("VersionCompare:versionCompare.documentation")
+        }
+      </Text>
     </div>
     <Flex.Spacer />
     <IconEx size="m" fill="informational">

--- a/packages/changed-elements-react/src/widgets/InformationButton.tsx
+++ b/packages/changed-elements-react/src/widgets/InformationButton.tsx
@@ -3,9 +3,8 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { SvgInfo } from "@itwin/itwinui-icons-react";
-import { Divider, DropdownMenu, IconButton, MenuExtraContent } from "@itwin/itwinui-react";
+import { DropdownMenu, IconButton, MenuExtraContent } from "@itwin/itwinui-react";
 import type { ReactNode } from "react";
-import { Documentation } from "./Documentation.js";
 
 interface Props {
   "data-testid"?: string;

--- a/packages/changed-elements-react/src/widgets/InformationButton.tsx
+++ b/packages/changed-elements-react/src/widgets/InformationButton.tsx
@@ -3,8 +3,9 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 import { SvgInfo } from "@itwin/itwinui-icons-react";
-import { DropdownMenu, IconButton, MenuExtraContent } from "@itwin/itwinui-react";
+import { Divider, DropdownMenu, IconButton, MenuExtraContent } from "@itwin/itwinui-react";
 import type { ReactNode } from "react";
+import { Documentation } from "./Documentation.js";
 
 interface Props {
   "data-testid"?: string;
@@ -18,7 +19,7 @@ interface Props {
 function InfoButton(props: Props) {
   return (
     <DropdownMenu
-      style={{ width: 500 }}
+      style={{ width: 400 }}
       placement="bottom-end"
       menuItems={() => [
         <MenuExtraContent key={0}>

--- a/packages/test-app-frontend/src/App/ITwinJsApp/ITwinJsApp.tsx
+++ b/packages/test-app-frontend/src/App/ITwinJsApp/ITwinJsApp.tsx
@@ -316,6 +316,7 @@ class MainFrontstageItemsProvider implements UiItemsProvider {
               manager={VersionCompare.manager}
               manageVersions={<ManageNamedVersions />}
               feedbackUrl="https://example.com"
+              documentationHref="https://example.com"
             />
           ),
         },
@@ -323,11 +324,13 @@ class MainFrontstageItemsProvider implements UiItemsProvider {
     } else {
       return [{
         id: "ChangedElementsWidget",
-        content: <ChangedElementsWidget useV2Widget
+        content: <ChangedElementsWidget
+          useV2Widget
           feedbackUrl="https://example.com"
           iModelConnection={UiFramework.getIModelConnection()!}
           enableComparisonJobUpdateToasts
           manageNamedVersionsSlot={<ManageNamedVersions />}
+          documentationHref="https://example.com"
         />,
       }];
     }


### PR DESCRIPTION
---
"@itwin/changed-elements-react": minor
---

- Added ability to add custom documentation link to information pane.
  Pass href into top level widget as prop.
  
  
![image](https://github.com/user-attachments/assets/8e2d0f4f-c269-4a6e-9d21-ee37b0eae54c)
