### PR TITLE
Naron/search pill missing returning from version compare frontstage

### DIFF
--- a/.changeset/upset-lizards-reply.md
+++ b/.changeset/upset-lizards-reply.md
@@ -1,0 +1,5 @@
+---
+"@itwin/changed-elements-react": patch
+---
+
+bug on filter pill missing after switching page

--- a/packages/changed-elements-react/src/common/ExpandableSearchBar/ExpandableSearchBar.tsx
+++ b/packages/changed-elements-react/src/common/ExpandableSearchBar/ExpandableSearchBar.tsx
@@ -38,6 +38,9 @@ export interface ExpandableSearchBarProps {
 
   /** On search text change handler. */
   onChange?: (searchText: string) => void;
+
+  /** searched text preserved when switching to front stage */
+  searchedText?: string;
 }
 
 /**
@@ -62,9 +65,10 @@ export function ExpandableSearchBar({
   valueChangedDelay,
   onChange,
   setFocus = false,
+  searchedText = "",
 }: ExpandableSearchBarProps): ReactElement {
   const [expanded, setExpanded] = useState(false);
-  const [searchText, setSearchText] = useState<string>();
+  const [searchText, setSearchText] = useState<string>(searchedText);
   const [timeoutId, setTimeoutId] = useState(0);
   const inputElement = useRef<HTMLInputElement>(null);
 

--- a/packages/changed-elements-react/src/widgets/EnhancedElementsInspector.tsx
+++ b/packages/changed-elements-react/src/widgets/EnhancedElementsInspector.tsx
@@ -195,6 +195,7 @@ interface FilterHeaderProps {
   wantPropertyFiltering?: boolean;
   iModelConnection: IModelConnection | undefined;
   onSearchChanged?: (newFilter: string) => void;
+  searchedText: string | undefined;
 }
 
 function ChangeTypeFilterHeader(props: FilterHeaderProps): ReactElement {
@@ -407,6 +408,7 @@ function ChangeTypeFilterHeader(props: FilterHeaderProps): ReactElement {
         setFocus={true}
         valueChangedDelay={500}
         onChange={props.onSearchChanged}
+        searchedText={props.searchedText}
       >
         <IconButton
           size="small"
@@ -1411,6 +1413,7 @@ export class ChangedElementsListComponent extends Component<ChangedElementsListP
           onShowAll={this.onHandleShowAll}
           onHideAll={this.onHandleHideAll}
           onInvert={this.onInvert}
+          searchedText={this.state.search}
         />
         <ChangedElementsBreadCrumb
           rootLabel={IModelApp.localization.getLocalizedString(


### PR DESCRIPTION
#102 

pass down `search` in preserved state when initializing `ExpandableSearchBar`