### PR TITLE
search message showing returning from version compare frontstage

### DIFF
--- a/.changeset/yummy-symbols-send.md
+++ b/.changeset/yummy-symbols-send.md
@@ -1,0 +1,5 @@
+---
+"@itwin/changed-elements-react": patch
+---
+
+bug fix for search showing returning from version compare frontstage

--- a/packages/changed-elements-react/src/widgets/EnhancedElementsInspector.tsx
+++ b/packages/changed-elements-react/src/widgets/EnhancedElementsInspector.tsx
@@ -492,7 +492,7 @@ export class ChangedElementsListComponent extends Component<ChangedElementsListP
         nodes: ChangedElementsListComponent._maintainedState.nodes,
         selectedIds: ChangedElementsListComponent._maintainedState.selectedIds,
         path: ChangedElementsListComponent._maintainedState.path,
-        searchPath: ChangedElementsListComponent._maintainedState.path,
+        searchPath: ChangedElementsListComponent._maintainedState.searchPath,
         search: ChangedElementsListComponent._maintainedState.search,
         filteredNodes: ChangedElementsListComponent._maintainedState.filteredNodes,
         filterOptions: ChangedElementsListComponent._maintainedState.filterOptions,


### PR DESCRIPTION
#103 

Let me know if this is intentional to assign `path` to `searchpath`.

Feel like its just a minor typo. Looking at the code I think `searchpath` and `path` serves different purposes.
