### PR TITLE
Naron/nv table loading

### DIFF
--- a/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
+++ b/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
@@ -103,10 +103,11 @@ export function NamedVersionSelectorWidget(props: Readonly<NamedVersionSelectorW
     currentChangesetId,
   });
 
+  manager.currentVersion = currentNamedVersion
   const widgetRef = useRef<ChangedElementsWidget>(null);
 
   const onNamedVersionOpened = async (targetVersion?: NamedVersionEntry) => {
-    // manager.targetVersion = targetVersion?.namedVersion;
+    manager.targetVersion = targetVersion?.namedVersion;
     if (!targetVersion || !currentNamedVersion || targetVersion.job?.status !== "Completed") {
       return;
     }
@@ -135,19 +136,6 @@ export function NamedVersionSelectorWidget(props: Readonly<NamedVersionSelectorW
     // manager.versionCompareStopped.addOnce(() => {}); @naron: need to test on versionCompareStopped
   };
 
-  // if (!isComparing) {
-  //   return (
-  //     <NamedVersionSelector
-  //       iModel={iModel}
-  //       manager={manager}
-  //       emptyState={emptyState}
-  //       manageVersions={manageVersions}
-  //       feedbackUrl={feedbackUrl}
-  //       documentationHref = {props.documentationHref}
-  //     />
-  //   );
-  // }
-
   return (
     <Widget>
       <Widget.Header>
@@ -159,12 +147,11 @@ export function NamedVersionSelectorWidget(props: Readonly<NamedVersionSelectorW
         </TextEx>
 
         {
-          // @naron: what does this do??
-          !isComparing && manager.currentVersion &&
+          !isComparisonStarted &&
           <ChangedElementsHeaderButtons documentationHref={props.documentationHref} onlyInfo />
         }
 
-        {isComparing &&
+        {isComparisonStarted &&
         <div>
           <ChangedElementsHeaderButtons
             useNewNamedVersionSelector
@@ -195,7 +182,7 @@ export function NamedVersionSelectorWidget(props: Readonly<NamedVersionSelectorW
           entries={entries}
           updateJobStatus={updateJobStatus}
           onNamedVersionOpened={onNamedVersionOpened}
-          emptyState={emptyState}
+          emptyState={emptyState} // @naron: this is never used
           manageVersions={manageVersions}
           feedbackUrl={feedbackUrl}
           documentationHref = {props.documentationHref}
@@ -296,55 +283,18 @@ interface NamedVersionSelectorProps {
   documentationHref?: string;
 }
 
-function NamedVersionSelector(props: Readonly<NamedVersionSelectorProps>): ReactElement {
-
-  const {
-    iModel,
-    isLoading,
-    currentNamedVersion,
-    entries,
-    updateJobStatus,
-    onNamedVersionOpened,
-    emptyState,
-    manageVersions,
-    feedbackUrl } = props;
-
-  //@naron: this is repeated also
-  const iTwinId = iModel.iTwinId as string;
-  const iModelId = iModel.iModelId as string;
-
-  // const [currentSillyVersion, setCurrentSillyVersion] = useState<NamedVersion>({
-  //   id: "",
-  //   displayName: "",
-  //   description: "",
-  //   changesetId: currentChangesetId,
-  //   changesetIndex: 0,
-  //   description: "",
-  //   createdDateTime: "",
-  //   });
-
-  // useEffect(() => {
-  //   if (currentNamedVersion){
-  //     setCurrentSillyVersion(currentNamedVersion)
-  //   }
-  // },[currentNamedVersion])
-
-
-  const namedVersionSelectorProps: Readonly<NamedVersionSelectorContentProps> = {
-    isLoading,
-    currentNamedVersion,
-    entries,
-    iTwinId,
-    iModelId,
-    onNamedVersionOpened,
-    updateJobStatus,
-    emptyState,
-    manageVersions,
-  };
-
+function NamedVersionSelector({
+  iModel: { iTwinId, iModelId },
+  feedbackUrl,
+  ...rest
+}: Readonly<NamedVersionSelectorProps>): ReactElement {
   return (
     <>
-      <NamedVersionSelectorContent {...namedVersionSelectorProps} />
+      <NamedVersionSelectorContent
+        {...rest} // @naron: i could use useContext passing down props?
+        iTwinId={iTwinId as string}
+        iModelId={iModelId as string}
+      />
       <div className="_cer_v1_feedback_btn_container">
         {feedbackUrl && <FeedbackButton feedbackUrl={feedbackUrl} />}
       </div>

--- a/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelectorContext.tsx
+++ b/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelectorContext.tsx
@@ -5,6 +5,7 @@
 import { createContext } from "react";
 
 import type { NamedVersionEntry } from "./useNamedVersionsList.js";
+import { NamedVersionSelectorContentProps } from "./NamedVersionSelector.js";
 
 export interface NamedVersionSelectorContextValue {
   /** Invoked when users request Named Version processinig. */
@@ -42,3 +43,7 @@ export const namedVersionSelectorContext = createContext<NamedVersionSelectorCon
   checkStatus: () => ({ cancel: () => { } }),
   contextExists: false,
 });
+
+export const NamedVersionSelectorContentContext = createContext<NamedVersionSelectorContentProps>(
+  {} as NamedVersionSelectorContentProps
+)

--- a/packages/changed-elements-react/src/VersionCompareContext.tsx
+++ b/packages/changed-elements-react/src/VersionCompareContext.tsx
@@ -57,3 +57,4 @@ export interface VersionCompareContextValue {
 }
 
 const versionCompareContext = createContext<VersionCompareContextValue | undefined>(undefined);
+

--- a/packages/changed-elements-react/src/api/VersionCompareManager.ts
+++ b/packages/changed-elements-react/src/api/VersionCompareManager.ts
@@ -449,7 +449,7 @@ export class VersionCompareManager {
 
       this.progressCoordinator.updateProgress(VersionCompareProgressStage.OpenTargetImodel, 100);
 
-      // Keep metadata around for UI uses and other queries
+      // // Keep metadata around for UI uses and other queries
       this.currentVersion = currentVersion;
       this.targetVersion = targetVersion;
 

--- a/packages/changed-elements-react/src/api/VersionCompareManager.ts
+++ b/packages/changed-elements-react/src/api/VersionCompareManager.ts
@@ -417,7 +417,6 @@ export class VersionCompareManager {
    */
   public async startComparisonV2(
     currentIModel: IModelConnection,
-    currentVersion: NamedVersion,
     targetVersion: NamedVersion,
     changedElements: ChangedElements[],
   ): Promise<boolean> {
@@ -448,11 +447,6 @@ export class VersionCompareManager {
       );
 
       this.progressCoordinator.updateProgress(VersionCompareProgressStage.OpenTargetImodel, 100);
-
-      // // Keep metadata around for UI uses and other queries
-      this.currentVersion = currentVersion;
-      this.targetVersion = targetVersion;
-
       this.progressCoordinator.updateProgress(VersionCompareProgressStage.InitComparison);
 
       let wantedModelClasses = [

--- a/packages/changed-elements-react/src/widgets/NamedVersionOpenedContext.tsx
+++ b/packages/changed-elements-react/src/widgets/NamedVersionOpenedContext.tsx
@@ -1,0 +1,8 @@
+import { createContext } from "react";
+import { VersionCompareContextValue } from "../VersionCompareContext.js";
+import { NamedVersionEntry } from "../NamedVersionSelector/useNamedVersionsList.js";
+
+export const NamedVersionContext = createContext<VersionCompareContextValue & {
+  onNamedVersionOpened: (target?: NamedVersionEntry) => void;
+}>(null!);
+//@naron: do i need this?

--- a/packages/changed-elements-react/src/widgets/NamedVersionOpenedContext.tsx
+++ b/packages/changed-elements-react/src/widgets/NamedVersionOpenedContext.tsx
@@ -1,8 +1,0 @@
-import { createContext } from "react";
-import { VersionCompareContextValue } from "../VersionCompareContext.js";
-import { NamedVersionEntry } from "../NamedVersionSelector/useNamedVersionsList.js";
-
-export const NamedVersionContext = createContext<VersionCompareContextValue & {
-  onNamedVersionOpened: (target?: NamedVersionEntry) => void;
-}>(null!);
-//@naron: do i need this?

--- a/packages/changed-elements-react/src/widgets/comparisonJobWidget/common/versionCompareV2WidgetUtils.ts
+++ b/packages/changed-elements-react/src/widgets/comparisonJobWidget/common/versionCompareV2WidgetUtils.ts
@@ -44,7 +44,6 @@ export const runManagerStartComparisonV2 = async (args: ManagerStartComparisonV2
   const changedElements = await args.comparisonJobClient.getComparisonJobResult(args.comparisonJob);
   VersionCompare.manager?.startComparisonV2(
     args.iModelConnection,
-    args.currentVersion,
     await updateTargetVersion(args.iModelConnection, args.targetVersion, args.iModelsClient),
     [changedElements.changedElements]).catch((e) => {
       Logger.logError(VersionCompare.logCategory, "Could not start version comparison: " + e);


### PR DESCRIPTION
- refactored `NamedVersionSelector`: merged `namedVersionCompareSelector` with the changedElement widget components into one in their parent component, and I extracted the NV table so that it stays throughout the phase changes. 

- applied useContext for NamedVersionSelector content related props.