### PR TITLE
changedElementsHeaderButtons spacing

### DIFF
--- a/.changeset/slimy-lines-heal.md
+++ b/.changeset/slimy-lines-heal.md
@@ -1,0 +1,5 @@
+---
+"@itwin/changed-elements-react": patch
+---
+
+spacing around che ele header buttons

--- a/packages/changed-elements-react/src/widgets/ChangedElementsWidget.scss
+++ b/packages/changed-elements-react/src/widgets/ChangedElementsWidget.scss
@@ -9,3 +9,8 @@
   text-align: center;
   padding: var(--iui-size-xs);
 }
+
+.header-buttons {
+  display: flex;
+  gap: var(--iui-size-xs);
+}

--- a/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
+++ b/packages/changed-elements-react/src/widgets/ChangedElementsWidget.tsx
@@ -529,7 +529,7 @@ export function ChangedElementsHeaderButtons(props: Readonly<ChangedElementsHead
   }
 
   return (
-    <>
+    <div className="header-buttons">
       {
         !props.useNewNamedVersionSelector &&
         <IconButton
@@ -589,7 +589,7 @@ export function ChangedElementsHeaderButtons(props: Readonly<ChangedElementsHead
           <SvgCompare />
         </IconButton>
       }
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
JP mentioned this when i worked on the bug on right aligning header button that he want a bit more spacing between those buttons.

the side effect of this change is when squeezing it becomes
![image](https://github.com/user-attachments/assets/bb71944c-6732-42ca-b82c-89795bcc68f5)
cuz of the fixed spacing


while previously if squeezed:
![image](https://github.com/user-attachments/assets/3344c4de-df5e-4670-a17c-9430a4c3cf03)

