### PR TITLE
elements visibility with toggle filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ pnpm-debug.log*
 .env.*
 
 packages/test-app-frontend/dist/
+*.DS_Store

--- a/packages/changed-elements-react/src/api/ChangedElementEntryCache.ts
+++ b/packages/changed-elements-react/src/api/ChangedElementEntryCache.ts
@@ -54,6 +54,7 @@ export interface ChangedElementEntry extends ChangedElement {
   directChildren?: string[];
   loaded: boolean;
   indirect?: boolean;
+  isTypeOfChangeFiltered?: boolean;
 }
 
 /** Cache for changed element entries that are maintained and populated with labels as we load labels with the cache */

--- a/packages/changed-elements-react/src/api/VersionCompareTiles.ts
+++ b/packages/changed-elements-react/src/api/VersionCompareTiles.ts
@@ -398,11 +398,11 @@ export class Provider
       if (this._internalAlwaysDrawn.size === 0 || this._internalAlwaysDrawn.has(elem.id)) {
         overrides.override({
           elementId: elem.id,
-          appearance: this._wantHideModified()
+          appearance: this._wantHideModified() || elem.isTypeOfChangeFiltered
             ? hiddenAppearance
             : elem.indirect
               ? updatedIndirectly
-              : updated
+              : updated,
          });
       }
     }
@@ -483,23 +483,23 @@ export class Provider
       );
     }
 
-    // // Handle modified elements that are in secondary iModel
-    // if (this._options?.wantModified && !this._wantHideModified()) {
-    //   const modifiedElemIds = new Set(
-    //     this.changedElems
-    //       .filter(
-    //         (entry: ChangedElement) =>
-    //           entry.opcode === DbOpcode.Update && !neverDrawn.has(entry.id),
-    //       )
-    //       .map((entry: ChangedElement) => entry.id),
-    //   );
-    //   // Set override for the modified element ids with the given color
-    //   this._overrideSecondaryIModelElements(
-    //     ovrs,
-    //     modifiedElemIds,
-    //     VersionCompareVisualizationManager.colorModifiedTargetRgb(),
-    //   );
-    // }
+    // Handle modified elements that are in secondary iModel
+    if (this._options?.wantModified && !this._wantHideModified()) {
+      const modifiedElemIds = new Set(
+        this.changedElems
+          .filter(
+            (entry: ChangedElement) =>
+              entry.opcode === DbOpcode.Update && !neverDrawn.has(entry.id),
+          )
+          .map((entry: ChangedElement) => entry.id),
+      );
+      // Set override for the modified element ids with the given color
+      this._overrideSecondaryIModelElements(
+        ovrs,
+        modifiedElemIds,
+        VersionCompareVisualizationManager.colorModifiedTargetRgb(),
+      );
+    }
 
     return ovrs;
   }

--- a/packages/changed-elements-react/src/api/VersionCompareVisualization.ts
+++ b/packages/changed-elements-react/src/api/VersionCompareVisualization.ts
@@ -18,6 +18,7 @@ import {
   isVersionComparisonDisplayEnabled, Provider as VersionCompareProvider, updateVersionCompareDisplayEntries,
   updateVersionComparisonDisplayOptions, type VersionDisplayOptions
 } from "./VersionCompareTiles.js";
+import { FilterOptions } from "../SavedFiltersManager.js";
 
 /**
  * Handles version compare visualization by using the VersionCompareTiles' provider
@@ -86,6 +87,7 @@ export class VersionCompareVisualizationManager {
       hideUnchanged: false,
       hideRemoved: false,
       hideModified: false,
+      hideAdded: false,
       wantModified: _wantSecondaryModified,
       emphasized: true,
     };
@@ -98,6 +100,19 @@ export class VersionCompareVisualizationManager {
     this._viewport.view.forEachModel((model: GeometricModelState) => {
       this._modelsAtStart.push(model.id);
     });
+  }
+
+  public updateDisplayOptions = (options: FilterOptions) => {
+    if (options.wantAdded !== undefined) {
+      this.displayOptions.hideAdded = !options.wantAdded;
+    }
+
+    if (options.wantModified !== undefined) {
+      this.displayOptions.hideModified = !options.wantModified;
+    }
+
+    this.displayOptions.hideUnchanged =
+      options.wantUnchanged !== undefined ? !options.wantUnchanged  : !this.displayOptions.hideUnchanged;
   }
 
   /**
@@ -150,6 +165,7 @@ export class VersionCompareVisualizationManager {
       hideUnchanged: false,
       hideRemoved: false,
       hideModified: false,
+      hideAdded: false,
     };
 
     await disableVersionComparisonDisplay(this._viewport);
@@ -285,9 +301,7 @@ export class VersionCompareVisualizationManager {
   }
 
   /** Toggles the visibility of unchanged elements during comparison */
-  public async toggleUnchangedVisibility(hide?: boolean): Promise<boolean> {
-    this.displayOptions.hideUnchanged =
-      hide !== undefined ? hide : !this.displayOptions.hideUnchanged;
+  public async toggleUnchangedVisibility(): Promise<boolean> {
     this.displayOptions.changedModels = this._changedModels;
     this.displayOptions.emphasized = true;
 


### PR DESCRIPTION
#119
https://github.com/iTwin/changed-elements/issues/119

- Updates & Modified changed elements now gets hidden when toggled off
- Type of change filtering also hides the elements instead of turning them grey
- should apply to all model node & elements nodes