### PR TITLE
Fix table flicker

### DIFF
--- a/.changeset/tall-dingos-watch.md
+++ b/.changeset/tall-dingos-watch.md
@@ -1,0 +1,5 @@
+---
+"@itwin/changed-elements-react": patch
+---
+
+Fix named version selector row flicker

--- a/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
+++ b/packages/changed-elements-react/src/NamedVersionSelector/NamedVersionSelector.tsx
@@ -737,7 +737,7 @@ function NamedVersionListEntry(props: Readonly<NamedVersionEntryProps>): ReactEl
   }
 
   return (
-    <ListItem className="_cer_v1_named-version-entry">
+    <ListItem className="_cer_v1_named-version-entry" style={props.style}>
       <Flex justifyContent="left" gap="5px" >
         <Flex.Item flex='2'>
           <div>


### PR DESCRIPTION
Fix NamedVersionSelector virtualized row flicker by applying react-window item style to each ListItem root so rows keep stable positioning during scroll.